### PR TITLE
feat: use fallback charm icon on img error

### DIFF
--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -1,5 +1,5 @@
 import { parseISO, formatDistanceToNow } from "date-fns";
-
+import { useState } from "react";
 import defaultCharmIcon from "static/images/icons/default-charm-icon.svg";
 
 export function generateEntityIdentifier(charmId, name, subordinate) {
@@ -329,13 +329,32 @@ export const extractRelationEndpoints = (relation) => {
   return endpoints;
 };
 
+const ImgWithFallback = ({
+  src,
+  fallback = defaultCharmIcon,
+  alt,
+  ...props
+}) => {
+  const [imgSrc, setImgSrc] = useState(src);
+  const onError = () => setImgSrc(fallback);
+
+  return (
+    <img
+      alt={alt}
+      src={imgSrc ? imgSrc : fallback}
+      onError={onError}
+      {...props}
+    />
+  );
+};
+
 export const generateIconImg = (name, charmId) => {
   let iconSrc = defaultCharmIcon;
   if (charmId.indexOf("local:") !== 0) {
     iconSrc = generateIconPath(charmId);
   }
   return (
-    <img
+    <ImgWithFallback
       alt={name + " icon"}
       key={name}
       title={name}

--- a/src/components/Topology/Topology.js
+++ b/src/components/Topology/Topology.js
@@ -2,6 +2,7 @@ import { useRef, useEffect } from "react";
 import * as d3 from "d3";
 import cloneDeep from "clone-deep";
 
+import defaultCharmIcon from "static/images/icons/default-charm-icon.svg";
 import { generateIconPath } from "app/utils/utils";
 
 /**
@@ -241,6 +242,10 @@ const Topology = ({
     appIcon
       .append("image")
       .attr("xlink:href", (d) => generateIconPath(d["charm-url"]))
+      // use a fallback image if the icon is not found
+      .on("error", function () {
+        d3.select(this).attr("xlink:href", () => defaultCharmIcon);
+      })
       .attr("width", (d) => (isSubordinate(d) ? 96 : 126))
       .attr("height", (d) => (isSubordinate(d) ? 96 : 126))
       .attr("transform", (d) =>


### PR DESCRIPTION
## Done

- use fallback charm icon on img load error

Fixes: https://github.com/canonical-web-and-design/jaas-dashboard/issues/1230

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Verify that any images that fail to load use the default icon as a fallback 

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

### Before
<img width="540" alt="image" src="https://user-images.githubusercontent.com/7452681/173089490-a0b5318f-79bc-4575-8c7f-68f398db7998.png">



### After
<img width="539" alt="image" src="https://user-images.githubusercontent.com/7452681/173089151-e4766b73-11b7-4ed3-8c44-8af8668c693b.png">

