### PR TITLE
Updated to use current facades for Juju 3.0.

### DIFF
--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -1,14 +1,14 @@
 import Limiter from "async-limiter";
 import { connect, connectAndLogin } from "@canonical/jujulib";
 
-import actions from "@canonical/jujulib/dist/api/facades/action-v6";
-import allWatcher from "@canonical/jujulib/dist/api/facades/all-watcher-v1";
+import actions from "@canonical/jujulib/dist/api/facades/action-v7";
+import allWatcher from "@canonical/jujulib/dist/api/facades/all-watcher-v2";
 import annotations from "@canonical/jujulib/dist/api/facades/annotations-v2";
-import applications from "@canonical/jujulib/dist/api/facades/application-v12";
-import client from "@canonical/jujulib/dist/api/facades/client-v2";
-import cloud from "@canonical/jujulib/dist/api/facades/cloud-v3";
-import controller from "@canonical/jujulib/dist/api/facades/controller-v5";
-import modelManager from "@canonical/jujulib/dist/api/facades/model-manager-v5";
+import applications from "@canonical/jujulib/dist/api/facades/application-v14";
+import client from "@canonical/jujulib/dist/api/facades/client-v5";
+import cloud from "@canonical/jujulib/dist/api/facades/cloud-v7";
+import controller from "@canonical/jujulib/dist/api/facades/controller-v11";
+import modelManager from "@canonical/jujulib/dist/api/facades/model-manager-v9";
 import pinger from "@canonical/jujulib/dist/api/facades/pinger-v1";
 
 import jimm from "app/jimm-facade";
@@ -47,8 +47,8 @@ function generateConnectionOptions(usePinger = false, bakery, onClose) {
     client,
     cloud,
     controller,
-    jimm,
     modelManager,
+    jimm,
   ];
   if (usePinger) {
     facades.push(pinger);


### PR DESCRIPTION
## Done

Updated to drop deprecated facades. 

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/

## Details

This is a WIP of a version of the dashboard that works against Juju 3.0.

Note: currently, this will fail if built as is. You need to build a fresh version of js-libjuju, yarn link it, and then drop some kludges into a Dockerfile. This PR will be ready to merge once I can delete this sentence, and the below patch to the Dockerfile:

```
diff --git a/Dockerfile b/Dockerfile
index e3cb23cc..37ad7f6f 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,11 @@
 # syntax=docker/dockerfile:experimental
 
-# Build stage: Install yarn dependencies
-# ===
-FROM node:16 AS yarn-dependencies
+FROM node:16 as build-js
 
 WORKDIR /srv
 
-ADD package.json yarn.lock .
-RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
-
-
-# Build stage: Run "yarn run build-js"
-# ===
-FROM yarn-dependencies AS build-js
-ADD . .
-RUN yarn run build
-
+COPY juju-dashboard-v0.9.3.tgz .
+RUN tar xvzf juju-dashboard-v0.9.3.tgz
 
 FROM ubuntu:focal
 
@@ -25,6 +15,6 @@ WORKDIR /srv
 
 COPY nginx.conf /etc/nginx/sites-available/default
 COPY entrypoint entrypoint
-COPY --from=build-js /srv/build .
+COPY --from=build-js /srv/package .
 
 ENTRYPOINT ["./entrypoint"]
```
