### PR TITLE
Get missing action logs

### DIFF
--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -1,5 +1,5 @@
-import Limiter from "async-limiter";
 import { connect, connectAndLogin } from "@canonical/jujulib";
+import Limiter from "async-limiter";
 
 import actions from "@canonical/jujulib/dist/api/facades/action-v6";
 import allWatcher from "@canonical/jujulib/dist/api/facades/all-watcher-v1";
@@ -18,9 +18,9 @@ import {
   getBakery,
   getConfig,
   getControllerConnection,
-  isLoggedIn,
   getUserPass,
   getWSControllerURL,
+  isLoggedIn,
 } from "app/selectors";
 import {
   addControllerCloudRegion,
@@ -479,6 +479,12 @@ export async function queryOperationsList(queryArgs, modelUUID, appState) {
     queryArgs
   );
   return operationListResult;
+}
+
+export async function queryActionsList(queryArgs, modelUUID, appState) {
+  const conn = await connectAndLoginToModel(modelUUID, appState);
+  const actionsListResult = await conn.facades.action.actions(queryArgs);
+  return actionsListResult;
 }
 
 export async function startModelWatcher(modelUUID, appState, dispatch) {

--- a/src/pages/EntityDetails/Model/ActionLogs/ActionLogs.test.js
+++ b/src/pages/EntityDetails/Model/ActionLogs/ActionLogs.test.js
@@ -9,12 +9,19 @@ import dataDump from "testing/complete-redux-store-dump";
 import ActionLogs from "pages/EntityDetails/Model/ActionLogs/ActionLogs";
 import TestRoute from "components/Routes/TestRoute";
 import { waitForComponentToPaint } from "testing/utils";
+import { act } from "react-dom/test-utils";
 
 jest.mock("juju", () => {
   return {
     queryOperationsList: () => {
       return new Promise((resolve) => {
         const apiData = require("testing/list-operations-api-response.json");
+        resolve(apiData.response);
+      });
+    },
+    queryActionsList: () => {
+      return new Promise((resolve) => {
+        const apiData = require("testing/list-actions-api-response.json");
         resolve(apiData.response);
       });
     },
@@ -46,9 +53,25 @@ describe("Action Logs", () => {
   it("requests the action logs data on load", async () => {
     const wrapper = await generateComponent();
     const expected = [
-      ["easyrsa", "1/list-disks", "completed", "", "", ""],
-      ["└easyrsa/0", "", "completed", "2", "-", "2021-04-14T20:27:57Z"],
-      ["└easyrsa/1", "", "completed", "3", "-", "2021-04-14T20:27:57Z"],
+      ["easyrsa", "1/list-disks", "completed", "", "", "", ""],
+      [
+        "└easyrsa/0",
+        "",
+        "completed",
+        "2",
+        "log message 1",
+        new Date("2021-04-14T20:27:57Z").toLocaleString(),
+        "Output",
+      ],
+      [
+        "└easyrsa/1",
+        "",
+        "completed",
+        "3",
+        "log message 1log message 2error message",
+        new Date("2021-04-14T20:27:57Z").toLocaleString(),
+        "Output",
+      ],
     ];
     const result = [];
     wrapper.find("tbody TableRow").forEach((row, rowIndex) => {
@@ -57,7 +80,7 @@ describe("Action Logs", () => {
         result[rowIndex].push(cell.text());
       });
     });
-    expect(expected).toEqual(result);
+    expect(result).toEqual(expected);
   });
 
   it("fails gracefully if app does not exist in model data", async () => {
@@ -67,9 +90,25 @@ describe("Action Logs", () => {
 
     const wrapper = await generateComponent();
     const expected = [
-      ["easyrsa", "1/list-disks", "completed", "", "", ""],
-      ["└easyrsa/0", "", "completed", "2", "-", "2021-04-14T20:27:57Z"],
-      ["└easyrsa/1", "", "completed", "3", "-", "2021-04-14T20:27:57Z"],
+      ["easyrsa", "1/list-disks", "completed", "", "", "", ""],
+      [
+        "└easyrsa/0",
+        "",
+        "completed",
+        "2",
+        "log message 1",
+        new Date("2021-04-14T20:27:57Z").toLocaleString(),
+        "Output",
+      ],
+      [
+        "└easyrsa/1",
+        "",
+        "completed",
+        "3",
+        "log message 1log message 2error message",
+        new Date("2021-04-14T20:27:57Z").toLocaleString(),
+        "Output",
+      ],
     ];
     const result = [];
     wrapper.find("tbody TableRow").forEach((row, rowIndex) => {
@@ -78,6 +117,54 @@ describe("Action Logs", () => {
         result[rowIndex].push(cell.text());
       });
     });
-    expect(expected).toEqual(result);
+    expect(result).toEqual(expected);
+  });
+  it("Only shows messages of selected type", async () => {
+    const clonedData = cloneDeep(dataDump);
+    delete clonedData.juju.modelData["57650e3c-815f-4540-89df-81fdfakeb7ef"]
+      .easyrsa;
+
+    const wrapper = await generateComponent();
+    const expected = [
+      ["easyrsa", "1/list-disks", "completed", "", "", "", ""],
+      [
+        "└easyrsa/0",
+        "",
+        "completed",
+        "2",
+        "log message 1",
+        new Date("2021-04-14T20:27:57Z").toLocaleString(),
+        "STDOUT",
+      ],
+      [
+        "└easyrsa/1",
+        "",
+        "completed",
+        "3",
+        "error message",
+        new Date("2021-04-14T20:27:57Z").toLocaleString(),
+        "STDERR",
+      ],
+    ];
+    const result = [];
+    wrapper.find("tbody TableRow").forEach((row, rowIndex) => {
+      // choose only stdout for action 1
+      if (rowIndex > 0) {
+        row.find("ContextualMenu").simulate("click");
+        act(() => {
+          // select stdout for the first action logs item and stderr for the second one
+          const stdoutElement = row.find("ContextualMenu").props().links[
+            rowIndex
+          ];
+          stdoutElement.onClick();
+        });
+      }
+      // choose only stderr for action 2
+      result.push([]);
+      row.find("TableCell").forEach((cell) => {
+        result[rowIndex].push(cell.text());
+      });
+    });
+    expect(result).toEqual(expected);
   });
 });

--- a/src/pages/EntityDetails/Model/ActionLogs/_action-logs.scss
+++ b/src/pages/EntityDetails/Model/ActionLogs/_action-logs.scss
@@ -1,0 +1,14 @@
+@import "../../../../scss/settings";
+@import "vanilla-framework/scss/vanilla";
+
+@mixin action-logs {
+  .action-logs__stdout {
+    display: block;
+  }
+
+  .action-logs__stderr {
+    color: $color-negative;
+  }
+}
+
+@include action-logs;

--- a/src/testing/list-actions-api-response.json
+++ b/src/testing/list-actions-api-response.json
@@ -1,0 +1,53 @@
+{
+  "request-id": 3,
+  "response": {
+    "results": [
+      {
+        "action": {
+          "tag": "action-2",
+          "receiver": "unit-easyrsa-0",
+          "name": "list-disks"
+        },
+        "enqueued": "2021-04-14T20:27:56Z",
+        "started": "2021-04-14T20:27:57Z",
+        "completed": "2021-04-14T20:27:57Z",
+        "status": "completed",
+        "log": [
+          {
+            "timestamp": "2021-04-14T20:27:57Z",
+            "message": "log message 1"
+          }
+        ],
+        "output": {
+          "return-code": 0
+        }
+      },
+      {
+        "action": {
+          "tag": "action-3",
+          "receiver": "unit-easyrsa-1",
+          "name": "list-disks"
+        },
+        "enqueued": "2021-04-14T20:27:57Z",
+        "started": "2021-04-14T20:27:57Z",
+        "completed": "2021-04-14T20:27:57Z",
+        "status": "failed",
+        "message": "error message",
+        "log": [
+          {
+            "timestamp": "2021-04-14T20:27:57Z",
+            "message": "log message 1"
+          },
+          {
+            "timestamp": "2021-04-14T20:27:57Z",
+            "message": "log message 2"
+          }
+        ],
+        "output": {
+          "return-code": 0,
+          "fortune": "custom message"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Done

- Show the output of the message
- Add the ability to filter the logs by `stderr`, `stdout` or both

### TODO
- Add a button maybe in `controls`, that will show the payload of `set_results` 

## QA

- Run the dashboard locally
- Open http://0.0.0.0:3000/
- Run a charm that has an action with logs, you can run this one (for some reason this charm successful action fail on juju 3.0 beta4): https://github.com/goulinkh/qa-juju-charm
- Make sure that the logs are present in the dashboard and match the defined behavior in [Figma](https://www.figma.com/file/u9v1jvPc3TwlfwHSWsysn9/JAAS-Baseline?node-id=530%3A38081)

## Details

Fixes #1199, #1035 

## Screenshots
![image](https://user-images.githubusercontent.com/36013798/194172070-1ee54eb6-f67e-4179-8e8d-4fc8eb225270.png)
