### PR TITLE
Revert renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,16 @@
 {
-  "extends": [
-    "github>canonical-web-and-design/renovate-websites"
+  "extends": ["config:base", "group:allNonMajor", "schedule:monthly"],
+  "labels": ["Maintenance"],
+  "packageRules": [
+    {
+      "groupName": "internal dependencies",
+      "groupSlug": "internal",
+      "packagePatterns": [
+        "^@canonical",
+        "^canonicalwebteam",
+        "^vanilla-framework"
+      ],
+      "schedule": ["at any time"]
+    }
   ]
 }


### PR DESCRIPTION
## Done

- Revert https://github.com/canonical/jaas-dashboard/pull/1224 so that we get more frequent updates (renovate was changed while this project wasn't getting a lot of attention).
- I made one change to the config which is to change the schedule from weekly to monthly (I thought it could be worth trying that cadence for a while).

## QA
n/a