### PR TITLE
Upgrade bakery dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@canonical/jaaslib": "0.6.1",
     "@canonical/jujulib": "2.0.0-beta.6",
-    "@canonical/macaroon-bakery": "1.0.0",
+    "@canonical/macaroon-bakery": "1.2.2",
     "@canonical/react-components": "0.24.0",
     "@sentry/browser": "7.14.0",
     "@types/clone-deep": "4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1870,10 +1870,10 @@
   dependencies:
     macaroon "^3.0.4"
 
-"@canonical/macaroon-bakery@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@canonical/macaroon-bakery/-/macaroon-bakery-1.0.0.tgz#b13324cf2cf5527cd827fb7b257146a133451405"
-  integrity sha512-eooOtBcvCtkBHL2T/2PAMiOyJwt7lzGmoPmsSHvyL4oGQRm3KdgDu7fb4VSlF7N/uV9SuaHZxzdEvbmffCcYOg==
+"@canonical/macaroon-bakery@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@canonical/macaroon-bakery/-/macaroon-bakery-1.2.2.tgz#bba6ff4f9212f0a3c301edfb7af864ff9b9773ee"
+  integrity sha512-wiY9L4DMdff8uLgrABKzQVUQy92mYVApz2ffpvRdNw/G0U9p3H7HouIEQsWHQwSKJC+gLIT/fE5o+hUDoF5Ixw==
   dependencies:
     macaroon "3.0.4"
 


### PR DESCRIPTION
## Done

- Update the bakery dep to 1.2.2. This release bundles the crypto libs in preparation for Webpack 5 (which does not polyfill node modules).

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Check that you can log in.

## Details

Fixes: #1246.
