### PR TITLE
add support for juju 3.0 beta4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "juju-dashboard",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "A dashboard for Juju and JAAS (Juju as a service)",
   "bugs": {
     "url": "https://github.com/canonical-web-and-design/jaas-dashboard/issues"
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@canonical/jaaslib": "0.6.1",
-    "@canonical/jujulib": "2.0.0-beta.6",
+    "@canonical/jujulib": "2.0.0-beta.8",
     "@canonical/macaroon-bakery": "1.2.2",
     "@canonical/react-components": "0.24.0",
     "@sentry/browser": "7.14.1",

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -1,14 +1,14 @@
 import { connect, connectAndLogin } from "@canonical/jujulib";
 import Limiter from "async-limiter";
 
-import actions from "@canonical/jujulib/dist/api/facades/action-v6";
-import allWatcher from "@canonical/jujulib/dist/api/facades/all-watcher-v1";
+import actions from "@canonical/jujulib/dist/api/facades/action-v7";
+import allWatcher from "@canonical/jujulib/dist/api/facades/all-watcher-v2";
 import annotations from "@canonical/jujulib/dist/api/facades/annotations-v2";
-import applications from "@canonical/jujulib/dist/api/facades/application-v12";
-import client from "@canonical/jujulib/dist/api/facades/client-v2";
-import cloud from "@canonical/jujulib/dist/api/facades/cloud-v3";
-import controller from "@canonical/jujulib/dist/api/facades/controller-v5";
-import modelManager from "@canonical/jujulib/dist/api/facades/model-manager-v5";
+import applications from "@canonical/jujulib/dist/api/facades/application-v14";
+import client from "@canonical/jujulib/dist/api/facades/client-v5";
+import cloud from "@canonical/jujulib/dist/api/facades/cloud-v7";
+import controller from "@canonical/jujulib/dist/api/facades/controller-v11";
+import modelManager from "@canonical/jujulib/dist/api/facades/model-manager-v9";
 import pinger from "@canonical/jujulib/dist/api/facades/pinger-v1";
 
 import jimm from "app/jimm-facade";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1087,22 +1087,15 @@
   resolved "https://registry.yarnpkg.com/@canonical/jaaslib/-/jaaslib-0.6.1.tgz#11eb43ba05e6e0c69e44a6947bd66fa1397ecefb"
   integrity sha512-Ts7TziwN3ZkB7bNpAnPoiSJQaDr9becHHx5AXaTl1uq/WKvscO0vtoa1QsBtksh5QMMuFlWn3Z2PmnfT4IVwmg==
 
-"@canonical/jujulib@2.0.0-beta.6":
-  version "2.0.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@canonical/jujulib/-/jujulib-2.0.0-beta.6.tgz#b3ba9c83278a9abca98a7f20245736409505710b"
-  integrity sha512-TLY9t8gi4n+BihAgk4LAF3gJ4JRKDUZPURB940sujeZs6fyvy7ovm+izElGKJGLWawFnJARuOe4SJKzht5WqtA==
+"@canonical/jujulib@2.0.0-beta.8":
+  version "2.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/@canonical/jujulib/-/jujulib-2.0.0-beta.8.tgz#600850a436adffd04664af99bcc3e2b123c4edc3"
+  integrity sha512-agSqwh0Ll3se9g1fFxUW4/atwEDupKjgyeQugZCzJMd0BLEkmOYh3od5IATkfO/gVzcu562GiDRZNGoO98/nsQ==
   dependencies:
-    "@canonical/macaroon-bakery" "0.3.0"
+    "@canonical/macaroon-bakery" "1.2.2"
     btoa "1.2.1"
-    websocket "1.0.33"
+    websocket "1.0.34"
     xhr2 "0.2.1"
-
-"@canonical/macaroon-bakery@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@canonical/macaroon-bakery/-/macaroon-bakery-0.3.0.tgz#59ec07ad31f392bea2364e81dd6b63ac78b32e6c"
-  integrity sha512-JtMXxasIMLMIVsqIfLMm6VObUcV5itq3WnEt02rV+39j7Z4wNDUM+HuiHQhcmUuogmMOgoyqfLuUHE0Wkk7F4A==
-  dependencies:
-    macaroon "^3.0.4"
 
 "@canonical/macaroon-bakery@1.2.2":
   version "1.2.2"
@@ -6974,7 +6967,7 @@ lz-string@^1.4.4:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
 
-macaroon@3.0.4, macaroon@^3.0.4:
+macaroon@3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/macaroon/-/macaroon-3.0.4.tgz#dac1a4b17cd973c1000703f40b19bdbb1d6191ce"
   integrity sha512-Tja2jvupseKxltPZbu5RPSz2Pgh6peYA3O46YCTcYL8PI1VqtGwDqRhGfP8pows26xx9wTiygk+en62Bq+Y8JA==
@@ -10400,10 +10393,10 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
-websocket@1.0.33:
-  version "1.0.33"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.33.tgz#407f763fc58e74a3fa41ca3ae5d78d3f5e3b82a5"
-  integrity sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==
+websocket@1.0.34:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
+  integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==
   dependencies:
     bufferutil "^4.0.1"
     debug "^2.2.0"


### PR DESCRIPTION
## Done

- Update the package `jujulib` to add support for Juju 3.0

## QA

- Run the Juju dashboard proxy: `juju dashboard`
- Add a new file at `public/config.local.js`:
```js
var jujuDashboardConfig = {
  controllerAPIEndpoint: "ws(s)://<your-dashboard-host:port>/api",
  baseAppURL: "/",
  identityProviderAvailable: false,
  identityProviderURL: "",
  isJuju: true,
};
```
- Run the dashboard locally: `yarn install && yarn start`
- Make sure that you can see the list of models

## Issues

Fixes #1274