### PR TITLE
[Dockerfile] append `/` to ADD path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM node:18 AS yarn-dependencies
 
 WORKDIR /srv
 
-ADD package.json yarn.lock .
+ADD package.json yarn.lock ./
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
 
 


### PR DESCRIPTION
## Done

- Added `/` to the end of ADD path to appease `docker build`

## QA

```
DOCKER_BUILDKIT=1 docker build .
```

## Details

`docker build` was failing with the following error:
```
Step 3/14 : ADD package.json yarn.lock .
When using ADD with more than one source file, the destination must be a directory and end with a /
```
This PR simply adds a `/` to the end of the destination path.