### PR TITLE
Truncate the machine status column

### DIFF
--- a/src/app/utils/utils.js
+++ b/src/app/utils/utils.js
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { parseISO, formatDistanceToNow } from "date-fns";
 import { useState } from "react";
 import defaultCharmIcon from "static/images/icons/default-charm-icon.svg";
@@ -20,14 +21,15 @@ export const generateStatusElement = (
   status = "unknown",
   count,
   useIcon = true,
-  actionsLogs = false
+  actionsLogs = false,
+  className = null
 ) => {
   let statusClass = status ? `is-${status.toLowerCase()}` : "";
   let countValue = "";
-  if (count !== undefined) {
+  if (count || count === 0) {
     countValue = ` (${count})`;
   }
-  const className = useIcon ? "status-icon " + statusClass : "";
+  const iconClasses = useIcon ? "status-icon " + statusClass : "";
   // ActionLogs uses a spinner icon if 'running'
   if (actionsLogs && statusClass === "is-running") {
     return (
@@ -39,7 +41,7 @@ export const generateStatusElement = (
   }
 
   return (
-    <span className={className}>
+    <span className={classNames(iconClasses, className)}>
       {status}
       {countValue}
     </span>

--- a/src/components/ButtonGroup/_button-group.scss
+++ b/src/components/ButtonGroup/_button-group.scss
@@ -26,6 +26,7 @@
     @include desktop {
       margin-bottom: 0;
     }
+
     @include large {
       width: auto;
     }

--- a/src/pages/EntityDetails/_entity-details.scss
+++ b/src/pages/EntityDetails/_entity-details.scss
@@ -179,12 +179,6 @@
 @mixin entity-details-tables {
   /* stylelint-disable no-descending-specificity */
   .p-main-table {
-    th,
-    td {
-      padding-left: 1rem;
-      padding-right: 1rem;
-    }
-
     tr {
       @include vf-animation(all, brisk, ease-in-out);
 
@@ -324,6 +318,12 @@
     }
   }
   /* stylelint-enable no-descending-specificity */
+
+  // Override the status icon so that it truncates inside the tooltip wrapper.
+  .entity-details__machines .status-icon,
+  .entity-details__machines-status-icon {
+    display: inline !important;
+  }
 }
 
 @mixin entity-details__button-group {

--- a/src/tables/tableHeaders.tsx
+++ b/src/tables/tableHeaders.tsx
@@ -52,7 +52,11 @@ export const generateSelectableUnitTableHeaders = (
 export const machineTableHeaders: Header = [
   { content: "machine", sortKey: "machine" },
   { content: "apps", sortKey: "apps" },
-  { content: "state", sortKey: "state" },
+  {
+    className: "p-table__cell--icon-placeholder",
+    content: "state",
+    sortKey: "state",
+  },
   { content: "az", sortKey: "az" },
   { content: "instance id", sortKey: "instanceId" },
   { content: "message", sortKey: "message" },

--- a/src/tables/tableRows.js
+++ b/src/tables/tableRows.js
@@ -9,6 +9,7 @@ import {
   generateIconImg,
   generateEntityIdentifier,
 } from "app/utils/utils";
+import { Tooltip } from "@canonical/react-components";
 
 export function generateLocalApplicationRows(
   applications,
@@ -374,8 +375,23 @@ export function generateMachineRows(
           className: "machine-app-icons",
         },
         {
-          content: generateStatusElement(machine["agent-status"].current),
-          className: "u-capitalise",
+          content: (
+            <Tooltip
+              className="u-truncate"
+              message={machine["agent-status"].current}
+              position="top-center"
+              positionElementClassName="entity-details__machines-status-icon"
+            >
+              {generateStatusElement(
+                machine["agent-status"].current,
+                null,
+                true,
+                false,
+                "p-icon u-truncate"
+              )}
+            </Tooltip>
+          ),
+          className: "u-capitalise u-truncate",
         },
         { content: az },
         { content: machine["instance-id"] },


### PR DESCRIPTION
## Done

- Truncate the machine status column on small screens.

## QA

- Go to a model -> Machines tab.
- On a large screen the status column should not be truncated.
- On a small screen the status column should truncate and you should be able to see the full status with a tooltip.

## Details

Fixes: #530.

## Screenshots

<img width="318" alt="Screenshot 2022-10-26 at 5 00 41 pm" src="https://user-images.githubusercontent.com/361637/198150769-cb09c46a-3a67-4acc-be64-22c611a8e754.png">
<img width="719" alt="Screenshot 2022-10-27 at 9 26 02 am" src="https://user-images.githubusercontent.com/361637/198150777-b4680e16-0a17-48eb-87f1-fefe9d67c5ba.png">

