### PR TITLE
WD-145 - Set the correct port

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
+PORT=8036
 # Sass path to allow Sass to reference NPM packages directly
 REACT_APP_SASS_PATH=node_modules:src
 # Extend Eslint config

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -152,4 +152,4 @@ jobs:
       - name: Run dotrun
         run: |
           dotrun &
-          curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost:3000
+          curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost:8036

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The default configuration setting for the Dashboard is to connect to public JAAS
 yarn && yarn start
 ```
 
-Then connect to the Dashboard from your browser at http://localhost:3000/.
+Then connect to the Dashboard from your browser at http://localhost:8036/.
 
 ### Release tests
 
@@ -115,7 +115,7 @@ You will need the latest [NodeJS LTS](https://nodejs.org/en/) and [yarn](https:/
 yarn && yarn start
 ```
 
-...and view the site locally at: http://localhost:3000/. Any changes you make to the code will be hot reloaded in the browser.
+...and view the site locally at: http://localhost:8036/. Any changes you make to the code will be hot reloaded in the browser.
 
 ### Developing while connected to a Juju controller
 
@@ -128,7 +128,7 @@ Assuming you already have a [Juju controller created](https://juju.is/docs/getti
   - `identityProviderAvailable` to `false`.
   - `isJuju` to `true`.
 - Start the Dashboard with `yarn start`.
-- You can now access the dashboard at http://localhost:3000/ and it'll require the log in credentials from the above `juju dashboard` command.
+- You can now access the dashboard at http://localhost:8036/ and it'll require the log in credentials from the above `juju dashboard` command.
 
 ### Running the tests.
 

--- a/src/components/ButtonGroup/_button-group.scss
+++ b/src/components/ButtonGroup/_button-group.scss
@@ -26,6 +26,7 @@
     @include desktop {
       margin-bottom: 0;
     }
+
     @include large {
       width: auto;
     }


### PR DESCRIPTION
## Done

- Set the correct port for dotrun.

## QA

- Pull code
- Run `dotrun`
- Open http://0.0.0.0:8036/
- The UI should appear at the correct port.
