### PR TITLE
WD-481 Store and fetch the bakery outside of the Redux store

### DIFF
--- a/src/@canonical/macaroon-bakery.d.ts
+++ b/src/@canonical/macaroon-bakery.d.ts
@@ -1,0 +1,1 @@
+declare module "@canonical/macaroon-bakery";

--- a/src/app/action-types.ts
+++ b/src/app/action-types.ts
@@ -1,0 +1,12 @@
+// Action labels - these are defined in a separate file to prevent circular imports.
+export const actionsList = {
+  logOut: "LOG_OUT",
+  connectAndPollControllers: "CONNECT_AND_POLL_CONTROLLERS",
+  storeConfig: "STORE_CONFIG",
+  storeLoginError: "STORE_LOGIN_ERROR",
+  storeUserPass: "STORE_USER_PASS",
+  storeVersion: "STORE_VERSION",
+  storeVisitURL: "STORE_VISIT_URL",
+  updateControllerConnection: "UPDATE_CONTROLLER_CONNECTION",
+  updatePingerIntervalId: "UPDATE_PINGER_INTERVAL_ID",
+};

--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -1,4 +1,6 @@
-import { getBakery, getPingerIntervalIds } from "app/selectors";
+import { getPingerIntervalIds } from "app/selectors";
+import bakery from "app/bakery";
+
 import {
   clearControllerData,
   clearModelData,
@@ -11,34 +13,9 @@ import {
   getUserPass,
   getWSControllerURL,
 } from "./selectors";
-
-// Action labels
-export const actionsList = {
-  logOut: "LOG_OUT",
-  connectAndPollControllers: "CONNECT_AND_POLL_CONTROLLERS",
-  storeBakery: "STORE_BAKERY",
-  storeConfig: "STORE_CONFIG",
-  storeLoginError: "STORE_LOGIN_ERROR",
-  storeUserPass: "STORE_USER_PASS",
-  storeVersion: "STORE_VERSION",
-  storeVisitURL: "STORE_VISIT_URL",
-  updateControllerConnection: "UPDATE_CONTROLLER_CONNECTION",
-  updatePingerIntervalId: "UPDATE_PINGER_INTERVAL_ID",
-};
+import { actionsList } from "./action-types";
 
 // Action creators
-/**
-  @param {Bakery} bakery The instance of the bakery that's to be used for the
-  application to interact as the active user. This bakery contains private data
-  and should not be dumped wholesale from the redux store.
-*/
-export function storeBakery(bakery) {
-  return {
-    type: actionsList.storeBakery,
-    payload: bakery,
-  };
-}
-
 /**
   @param {Object} config The configuration values for the application.
 */
@@ -131,7 +108,6 @@ export function logOut(store) {
     const state = store.getState();
     const identityProviderAvailable =
       state?.root?.config?.identityProviderAvailable;
-    const bakery = getBakery(state);
     const pingerIntervalIds = getPingerIntervalIds(state);
     bakery.storage._store.removeItem("identity");
     bakery.storage._store.removeItem("https://api.jujucharms.com/identity");

--- a/src/app/bakery.ts
+++ b/src/app/bakery.ts
@@ -1,0 +1,19 @@
+import { Bakery, BakeryStorage } from "@canonical/macaroon-bakery";
+
+import { storeVisitURL } from "app/actions";
+import reduxStore from "store/store";
+
+// This type can be remove once bakeryjs has been migrated to typescript.
+export type VisitPageInfo = {
+  WaitURL: string;
+  VisitURL: string;
+};
+
+const bakery = new Bakery({
+  visitPage: (resp: { Info: VisitPageInfo }) => {
+    reduxStore.dispatch(storeVisitURL(resp.Info.VisitURL));
+  },
+  storage: new BakeryStorage(localStorage, {}),
+});
+
+export default bakery;

--- a/src/app/check-auth.js
+++ b/src/app/check-auth.js
@@ -9,7 +9,6 @@ import { isLoggedIn } from "app/selectors";
 const actionAllowlist = [
   "POPULATE_MISSING_ALLWATCHER_DATA",
   "PROCESS_ALL_WATCHER_DELTAS",
-  "STORE_BAKERY",
   "STORE_LOGIN_ERROR",
   "STORE_CONFIG",
   "STORE_USER_PASS",

--- a/src/app/check-auth.js
+++ b/src/app/check-auth.js
@@ -3,7 +3,7 @@
   has been allowed.
 */
 
-import { actionsList } from "app/actions";
+import { actionsList } from "app/action-types";
 import { isLoggedIn } from "app/selectors";
 
 const actionAllowlist = [

--- a/src/app/root.js
+++ b/src/app/root.js
@@ -1,7 +1,9 @@
 import immerProduce from "immer";
 import cloneDeep from "clone-deep";
 
-import { actionsList } from "./actions";
+import bakery from "app/bakery";
+
+import { actionsList } from "./action-types";
 
 function rootReducer(state = {}, action) {
   return immerProduce(state, (draftState) => {
@@ -10,9 +12,6 @@ function rootReducer(state = {}, action) {
         const connections = cloneDeep(state.controllerConnections || {});
         connections[action.payload.wsControllerURL] = action.payload.info;
         draftState.controllerConnections = connections;
-        break;
-      case actionsList.storeBakery:
-        draftState.bakery = action.payload;
         break;
       case actionsList.storeConfig:
         draftState.config = action.payload;
@@ -32,7 +31,7 @@ function rootReducer(state = {}, action) {
         draftState.visitURL = action.payload;
         break;
       case actionsList.logOut:
-        delete draftState.bakery.storage._store.identity;
+        delete bakery.storage._store.identity;
         delete draftState.controllerConnections;
         delete draftState.visitURL;
         break;

--- a/src/app/root.js
+++ b/src/app/root.js
@@ -1,8 +1,6 @@
 import immerProduce from "immer";
 import cloneDeep from "clone-deep";
 
-import bakery from "app/bakery";
-
 import { actionsList } from "./action-types";
 
 function rootReducer(state = {}, action) {
@@ -31,7 +29,6 @@ function rootReducer(state = {}, action) {
         draftState.visitURL = action.payload;
         break;
       case actionsList.logOut:
-        delete bakery.storage._store.identity;
         delete draftState.controllerConnections;
         delete draftState.visitURL;
         break;

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -32,13 +32,6 @@ export const getModelData = (state) => {
 export const getControllerData = (state) => state?.juju?.controllers;
 
 /**
-  Fetches the bakery from state.
-  @param {Object} state The application state.
-  @returns {Object|Null} The bakery instance or null if none found.
-*/
-export const getBakery = (state) => state?.root?.bakery;
-
-/**
   Fetches the application config from state.
   @param {Object} state The application state.
   @returns {Config|Null} The config object or null if none found.

--- a/src/components/LogIn/LogIn.tsx
+++ b/src/components/LogIn/LogIn.tsx
@@ -1,6 +1,5 @@
 import { connectAndStartPolling, storeUserPass } from "app/actions";
 import {
-  getBakery,
   getConfig,
   getControllerConnections,
   getLoginError,
@@ -20,6 +19,7 @@ import { Spinner } from "@canonical/react-components";
 
 import { Config, ReduxState, TSFixMe } from "types";
 import FadeUpIn from "animations/FadeUpIn";
+import bakery from "app/bakery";
 
 import logo from "static/images/logo/logo-black-on-white.svg";
 
@@ -108,7 +108,6 @@ interface LoginElements extends HTMLFormControlsCollection {
 function UserPassForm() {
   const dispatch = useDispatch();
   const store = useStore<ReduxState>();
-  const bakery = useSelector(getBakery);
   const focus = useRef<HTMLInputElement>(null);
 
   function handleSubmit(

--- a/src/components/WebCLI/WebCLI.js
+++ b/src/components/WebCLI/WebCLI.js
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useSelector, useStore } from "react-redux";
+import { useStore } from "react-redux";
 
-import { getActiveUserTag, getBakery } from "app/selectors";
+import bakery from "app/bakery";
+import { getActiveUserTag } from "app/selectors";
 
 import useAnalytics from "../../hooks/useAnalytics";
 
@@ -23,7 +24,6 @@ const WebCLI = ({
   const wsMessageStore = useRef();
   let [output, setOutput] = useState("");
   const sendAnalytics = useAnalytics();
-  const bakery = useSelector(getBakery);
   const storeState = useStore().getState();
 
   const clearMessageBuffer = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,27 +1,14 @@
 import { StrictMode } from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
-import { applyMiddleware, combineReducers, createStore } from "redux";
-import thunk from "redux-thunk";
-import { composeWithDevTools } from "redux-devtools-extension";
 import process from "process";
-import { Bakery, BakeryStorage } from "@canonical/macaroon-bakery";
 import * as Sentry from "@sentry/browser";
 import App from "components/App/App";
-import checkAuth from "app/check-auth";
-import rootReducer from "app/root";
-import uiReducer from "ui";
 
-import {
-  connectAndStartPolling,
-  storeBakery,
-  storeConfig,
-  storeVersion,
-  storeVisitURL,
-} from "app/actions";
+import bakery from "app/bakery";
+import reduxStore from "store/store";
 
-import jujuReducer from "juju/reducer";
-import { modelPollerMiddleware } from "store/middleware/model-poller";
+import { connectAndStartPolling, storeConfig, storeVersion } from "app/actions";
 
 import packageJSON from "../package.json";
 
@@ -91,28 +78,9 @@ function bootstrap() {
     Sentry.setTag("isJuju", config.isJuju);
   }
 
-  const reduxStore = createStore(
-    combineReducers({
-      root: rootReducer,
-      juju: jujuReducer,
-      ui: uiReducer,
-    }),
-    // Order of the middleware is important
-    composeWithDevTools(
-      applyMiddleware(checkAuth, thunk, modelPollerMiddleware)
-    )
-  );
-
   reduxStore.dispatch(storeConfig(config));
   reduxStore.dispatch(storeVersion(appVersion));
 
-  const bakery = new Bakery({
-    visitPage: (resp) => {
-      reduxStore.dispatch(storeVisitURL(resp.Info.VisitURL));
-    },
-    storage: new BakeryStorage(localStorage, {}),
-  });
-  reduxStore.dispatch(storeBakery(bakery));
   if (config.identityProviderAvailable) {
     // If an identity provider is available then try and connect automatically
     // If not then wait for the login UI to trigger this

--- a/src/juju/action-types.ts
+++ b/src/juju/action-types.ts
@@ -1,0 +1,11 @@
+// Action labels - these are defined in a separate file to prevent circular imports.
+export const actionsList = {
+  clearControllerData: "CLEAR_CONTROLLER_DATA",
+  clearModelData: "CLEAR_MODEL_DATA",
+  updateControllerList: "UPDATE_CONTROLLER_LIST",
+  updateModelInfo: "UPDATE_MODEL_INFO",
+  updateModelStatus: "UPDATE_MODEL_STATUS",
+  updateModelList: "UPDATE_MODEL_LIST",
+  processAllWatcherDeltas: "PROCESS_ALL_WATCHER_DELTAS",
+  populateMissingAllWatcherData: "POPULATE_MISSING_ALLWATCHER_DATA",
+};

--- a/src/juju/actions.js
+++ b/src/juju/actions.js
@@ -2,17 +2,7 @@ import cloneDeep from "clone-deep";
 
 import { fetchAndStoreModelStatus } from "juju";
 
-// Action labels
-export const actionsList = {
-  clearControllerData: "CLEAR_CONTROLLER_DATA",
-  clearModelData: "CLEAR_MODEL_DATA",
-  updateControllerList: "UPDATE_CONTROLLER_LIST",
-  updateModelInfo: "UPDATE_MODEL_INFO",
-  updateModelStatus: "UPDATE_MODEL_STATUS",
-  updateModelList: "UPDATE_MODEL_LIST",
-  processAllWatcherDeltas: "PROCESS_ALL_WATCHER_DELTAS",
-  populateMissingAllWatcherData: "POPULATE_MISSING_ALLWATCHER_DATA",
-};
+import { actionsList } from "./action-types";
 
 // Action creators
 

--- a/src/juju/actions.test.js
+++ b/src/juju/actions.test.js
@@ -1,4 +1,5 @@
 import * as actions from "./actions";
+import { actionsList } from "./action-types";
 
 describe("action creators", () => {
   it("updateModelList", () => {
@@ -6,7 +7,7 @@ describe("action creators", () => {
     expect(
       actions.updateModelList(models, "wss://test.example.com")
     ).toStrictEqual({
-      type: actions.actionsList.updateModelList,
+      type: actionsList.updateModelList,
       payload: {
         models,
         wsControllerURL: "wss://test.example.com",

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -11,11 +11,11 @@ import controller from "@canonical/jujulib/dist/api/facades/controller-v11";
 import modelManager from "@canonical/jujulib/dist/api/facades/model-manager-v9";
 import pinger from "@canonical/jujulib/dist/api/facades/pinger-v1";
 
+import bakery from "app/bakery";
 import jimm from "app/jimm-facade";
 import { isSet } from "app/utils/utils";
 
 import {
-  getBakery,
   getConfig,
   getControllerConnection,
   getUserPass,
@@ -177,7 +177,6 @@ async function connectAndLoginWithTimeout(
 */
 export async function fetchModelStatus(modelUUID, wsControllerURL, getState) {
   const appState = getState();
-  const bakery = getBakery(appState);
   const baseWSControllerURL = getWSControllerURL(appState);
   const { identityProviderAvailable } = getConfig(appState);
   let useIdentityProvider = false;
@@ -379,7 +378,6 @@ export function disableControllerUUIDMasking(conn) {
   @returns {Object} conn The connection.
 */
 async function connectAndLoginToModel(modelUUID, appState) {
-  const bakery = getBakery(appState);
   const baseWSControllerURL = getWSControllerURL(appState);
   const { identityProviderAvailable } = getConfig(appState);
   const credentials = getUserPass(baseWSControllerURL, appState);

--- a/src/juju/reducer.js
+++ b/src/juju/reducer.js
@@ -2,7 +2,7 @@ import immerProduce from "immer";
 import cloneDeep from "clone-deep";
 import mergeWith from "lodash.mergewith";
 
-import { actionsList } from "./actions";
+import { actionsList } from "./action-types";
 import { processDeltas } from "./watchers";
 
 const defaultState = {

--- a/src/panels/RegisterController/RegisterController.js
+++ b/src/panels/RegisterController/RegisterController.js
@@ -1,9 +1,9 @@
 import { useState } from "react";
-import { useSelector, useDispatch, useStore } from "react-redux";
+import { useDispatch, useStore } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
-import { getBakery } from "app/selectors";
 import { connectAndStartPolling } from "app/actions";
+import bakery from "app/bakery";
 
 import classNames from "classnames";
 
@@ -18,7 +18,6 @@ export default function RegisterController() {
   const [formValues, setFormValues] = useState({});
   const dispatch = useDispatch();
   const reduxStore = useStore();
-  const bakery = useSelector(getBakery);
   const [additionalControllers, setAdditionalControllers] = useLocalStorage(
     "additionalControllers",
     []

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,6 +1,8 @@
 import { configure } from "enzyme";
 import Adapter from "@wojtekmaj/enzyme-adapter-react-17";
 import "@testing-library/jest-dom";
+import util from "util";
+import crypto from "crypto";
 
 configure({ adapter: new Adapter() });
 
@@ -19,3 +21,8 @@ if (!window.HTMLDivElement.prototype.animate) {
     "you may now remove the mock"
   );
 }
+
+// Provide node modules that are required by bakeryjs.
+global.TextDecoder = util.TextDecoder;
+global.TextEncoder = util.TextEncoder;
+global.crypto = crypto;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./store";

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -1,9 +1,9 @@
 import {
-  actionsList,
   storeLoginError,
   updateControllerConnection,
   updatePingerIntervalId,
 } from "app/actions";
+import { actionsList } from "app/action-types";
 import * as jujuModule from "juju";
 import { updateModelList } from "juju/actions";
 import { AnyAction, MiddlewareAPI } from "redux";

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -2,11 +2,11 @@ import { Middleware } from "redux";
 import * as Sentry from "@sentry/browser";
 
 import {
-  actionsList,
   storeLoginError,
   updateControllerConnection,
   updatePingerIntervalId,
 } from "app/actions";
+import { actionsList } from "app/action-types";
 import { isLoggedIn } from "app/selectors";
 import {
   disableControllerUUIDMasking,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,21 @@
+import { applyMiddleware, combineReducers, createStore } from "redux";
+import thunk from "redux-thunk";
+import { composeWithDevTools } from "redux-devtools-extension";
+
+import checkAuth from "app/check-auth";
+import rootReducer from "app/root";
+import jujuReducer from "juju/reducer";
+import { modelPollerMiddleware } from "store/middleware/model-poller";
+import uiReducer from "ui";
+
+const reduxStore = createStore(
+  combineReducers({
+    root: rootReducer,
+    juju: jujuReducer,
+    ui: uiReducer,
+  }),
+  // Order of the middleware is important
+  composeWithDevTools(applyMiddleware(checkAuth, thunk, modelPollerMiddleware))
+);
+
+export default reduxStore;

--- a/src/testing/complete-redux-store-dump.js
+++ b/src/testing/complete-redux-store-dump.js
@@ -13,18 +13,6 @@ export default {
       showWebCLI: false
     },
     appVersion: '0.4.0',
-    bakery: {
-      storage: {
-        _store: {
-          'https://api.staging.jujucharms.com/identity': 'W3siYyI6W3sJpZCB1c3NvU9aTmVmWHlzIn1d',
-          identity: 'W3siYyI6W3siaSaWRlbnRpdWRnpGQVpCV3BTcDRWLUl1UzF1SzgifV0=',
-          'https://api.jujucharms.com/identity': 'W3siYyI6W3siaSI6InRpbWUtYcDRWLUl1UzF1SzgifV0='
-        },
-        _services: {},
-        _charmstoreCookieSetter: null
-      },
-      _dischargeDisabled: false
-    },
     controllerConnections: {
       'wss://jimm.jujucharms.com/api': {
         controllerTag: 'controller-a030379a-940f-4760-8fcf-3062b41a04e7',


### PR DESCRIPTION
## Done

- Move bakery to a separate file.
- Replace selectors and reducers with bakery import.
- Update tests to use the new bakery setup.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Check that you can still log in/out and display models.
