### PR TITLE
WD-654: Only store controller info in Redux

### DIFF
--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -90,14 +90,14 @@ export function storeUserPass(wsControllerURL, credential) {
 
 /**
   @param {String} wsControllerURL The URL of the websocket connection.
-  @param {Object} conn The active controller connection.
+  @param {Object} info The controller connection info.
 */
-export function updateControllerConnection(wsControllerURL, conn) {
+export function updateControllerConnection(wsControllerURL, info) {
   return {
     type: actionsList.updateControllerConnection,
     payload: {
       wsControllerURL,
-      conn,
+      info,
     },
   };
 }

--- a/src/app/root.js
+++ b/src/app/root.js
@@ -8,7 +8,7 @@ function rootReducer(state = {}, action) {
     switch (action.type) {
       case actionsList.updateControllerConnection:
         const connections = cloneDeep(state.controllerConnections || {});
-        connections[action.payload.wsControllerURL] = action.payload.conn;
+        connections[action.payload.wsControllerURL] = action.payload.info;
         draftState.controllerConnections = connections;
         break;
       case actionsList.storeBakery:

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -466,8 +466,7 @@ export const getMacaroons = createSelector(
   @returns {Boolean} If the user is logged in.
 */
 export const isLoggedIn = (wsControllerURL, state) => {
-  return state.root.controllerConnections?.[wsControllerURL]?.info?.user
-    ?.identity;
+  return state.root.controllerConnections?.[wsControllerURL]?.user?.identity;
 };
 
 export const getControllerConnection = (wsControllerURL, state) =>
@@ -484,7 +483,7 @@ export const isConnecting = (state) => !!state.root.visitURL;
   @returns {String} The users userTag.
 */
 export const getActiveUserTag = (wsControllerURL, state) =>
-  state?.root?.controllerConnections?.[wsControllerURL]?.info.user.identity;
+  state?.root?.controllerConnections?.[wsControllerURL]?.user.identity;
 
 /**
   Returns a model status for the supplied modelUUID.

--- a/src/components/WebCLI/WebCLI.test.js
+++ b/src/components/WebCLI/WebCLI.test.js
@@ -110,7 +110,7 @@ describe("WebCLI", () => {
   it("supports macaroon based authentication", async () => {
     const clonedDataDump = cloneDeep(dataDump);
     clonedDataDump.root.controllerConnections["ws://localhost:1234/api"] = {
-      info: { user: { identity: "user-eggman@external" } },
+      user: { identity: "user-eggman@external" },
     };
     clonedDataDump.root.bakery.storage.get = (key) => {
       const macaroons = { "ws://localhost:1234": "WyJtYWMiLCAiYXJvb24iXQo=" };

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -344,7 +344,7 @@ export async function fetchControllerList(
         path: controllerConfig.config["controller-name"],
         uuid: controllerConfig.config["controller-uuid"],
         version: getControllerConnection(wsControllerURL, reduxStore.getState())
-          ?.info?.serverVersion,
+          ?.serverVersion,
         additionalController,
       },
     ];

--- a/src/pages/EntityDetails/Model/Model.test.tsx
+++ b/src/pages/EntityDetails/Model/Model.test.tsx
@@ -61,7 +61,7 @@ describe("Model", () => {
     );
     storeData.root.controllerConnections = {
       "wss://jimm.jujucharms.com/api": {
-        info: { user: { identity: "user-eggman@external" } },
+        user: { identity: "user-eggman@external" },
       },
     };
     storeData.juju.modelData = dataDump.juju.modelData;

--- a/src/testing/complete-redux-store-dump.js
+++ b/src/testing/complete-redux-store-dump.js
@@ -27,118 +27,13 @@ export default {
     },
     controllerConnections: {
       'wss://jimm.jujucharms.com/api': {
-        transport: {
-          _ws: {},
-          _counter: 20,
-          _callbacks: {},
-          _debug: false
-        },
-        info: {
-          controllerTag: 'controller-a030379a-940f-4760-8fcf-3062b41a04e7',
-          serverVersion: '2.8.3',
-          user: {
-            'display-name': 'eggman',
-            identity: 'user-eggman@external',
-            'controller-access': '',
-            'model-access': ''
-          }
-        },
-        facades: {
-          cloud: {
-            version: 3,
-            _transport: {
-              _ws: {},
-              _counter: 20,
-              _callbacks: {},
-              _debug: false
-            },
-            _info: {
-              controllerTag: 'controller-a030379a-940f-4760-8fcf-3062b41a04e7',
-              serverVersion: '2.8.3',
-              user: {
-                'display-name': 'eggman',
-                identity: 'user-eggman@external',
-                'controller-access': '',
-                'model-access': ''
-              }
-            }
-          },
-          controller: {
-            version: 5,
-            _transport: {
-              _ws: {},
-              _counter: 20,
-              _callbacks: {},
-              _debug: false
-            },
-            _info: {
-              controllerTag: 'controller-a030379a-940f-4760-8fcf-3062b41a04e7',
-              serverVersion: '2.8.3',
-              user: {
-                'display-name': 'eggman',
-                identity: 'user-eggman@external',
-                'controller-access': '',
-                'model-access': ''
-              }
-            }
-          },
-          jimM: {
-            _transport: {
-              _ws: {},
-              _counter: 20,
-              _callbacks: {},
-              _debug: false
-            },
-            _info: {
-              controllerTag: 'controller-a030379a-940f-4760-8fcf-3062b41a04e7',
-              serverVersion: '2.8.3',
-              user: {
-                'display-name': 'eggman',
-                identity: 'user-eggman@external',
-                'controller-access': '',
-                'model-access': ''
-              }
-            },
-            version: 2
-          },
-          modelManager: {
-            version: 5,
-            _transport: {
-              _ws: {},
-              _counter: 20,
-              _callbacks: {},
-              _debug: false
-            },
-            _info: {
-              controllerTag: 'controller-a030379a-940f-4760-8fcf-3062b41a04e7',
-              serverVersion: '2.8.3',
-              user: {
-                'display-name': 'eggman',
-                identity: 'user-eggman@external',
-                'controller-access': '',
-                'model-access': ''
-              }
-            }
-          },
-          pinger: {
-            version: 1,
-            _transport: {
-              _ws: {},
-              _counter: 20,
-              _callbacks: {},
-              _debug: false
-            },
-            _info: {
-              controllerTag: 'controller-a030379a-940f-4760-8fcf-3062b41a04e7',
-              serverVersion: '2.8.3',
-              user: {
-                'display-name': 'eggman',
-                identity: 'user-eggman@external',
-                'controller-access': '',
-                'model-access': ''
-              }
-            }
-          }
+        controllerTag: 'controller-a030379a-940f-4760-8fcf-3062b41a04e7',
+        serverVersion: '2.8.3',
+        user: {
+          'display-name': 'eggman',
+          identity: 'user-eggman@external',
+          'controller-access': '',
+          'model-access': ''
         }
       }
     },


### PR DESCRIPTION
## Done

- Remove controller connection (e.g. transport, facades) from the Redux store.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Check that you can log in/out and view models and controllers.
