### PR TITLE
Update jujulib to latest version (juju 3.0 stable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@canonical/jaaslib": "0.6.1",
-    "@canonical/jujulib": "2.0.0-beta.8",
+    "@canonical/jujulib": "3.0.1",
     "@canonical/macaroon-bakery": "1.2.2",
     "@canonical/react-components": "0.37.6",
     "@reduxjs/toolkit": "1.9.0",

--- a/src/juju/index.js
+++ b/src/juju/index.js
@@ -2,10 +2,10 @@ import { connect, connectAndLogin } from "@canonical/jujulib";
 import Limiter from "async-limiter";
 
 import actions from "@canonical/jujulib/dist/api/facades/action-v7";
-import allWatcher from "@canonical/jujulib/dist/api/facades/all-watcher-v2";
+import allWatcher from "@canonical/jujulib/dist/api/facades/all-watcher-v3";
 import annotations from "@canonical/jujulib/dist/api/facades/annotations-v2";
-import applications from "@canonical/jujulib/dist/api/facades/application-v14";
-import client from "@canonical/jujulib/dist/api/facades/client-v5";
+import applications from "@canonical/jujulib/dist/api/facades/application-v15";
+import client from "@canonical/jujulib/dist/api/facades/client-v6";
 import cloud from "@canonical/jujulib/dist/api/facades/cloud-v7";
 import controller from "@canonical/jujulib/dist/api/facades/controller-v11";
 import modelManager from "@canonical/jujulib/dist/api/facades/model-manager-v9";
@@ -492,7 +492,7 @@ export async function startModelWatcher(modelUUID, appState, dispatch) {
       {
         type: "AllWatcher",
         request: "Next",
-        version: 1,
+        version: conn.facades.allWatcher.version,
         id: watcherHandle["watcher-id"],
       },
       callback
@@ -511,7 +511,7 @@ export async function stopModelWatcher(
   conn.facades.allWatcher._transport.write({
     type: "AllWatcher",
     request: "Stop",
-    version: 1,
+    version: conn.facades.allWatcher.version,
     id: watcherHandleId,
   });
   stopPingerLoop(pingerIntervalId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,10 +1092,10 @@
   resolved "https://registry.yarnpkg.com/@canonical/jaaslib/-/jaaslib-0.6.1.tgz#11eb43ba05e6e0c69e44a6947bd66fa1397ecefb"
   integrity sha512-Ts7TziwN3ZkB7bNpAnPoiSJQaDr9becHHx5AXaTl1uq/WKvscO0vtoa1QsBtksh5QMMuFlWn3Z2PmnfT4IVwmg==
 
-"@canonical/jujulib@2.0.0-beta.8":
-  version "2.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@canonical/jujulib/-/jujulib-2.0.0-beta.8.tgz#600850a436adffd04664af99bcc3e2b123c4edc3"
-  integrity sha512-agSqwh0Ll3se9g1fFxUW4/atwEDupKjgyeQugZCzJMd0BLEkmOYh3od5IATkfO/gVzcu562GiDRZNGoO98/nsQ==
+"@canonical/jujulib@3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@canonical/jujulib/-/jujulib-3.0.1.tgz#85f952f50968b0e5f0d0e20fad015a70447c342a"
+  integrity sha512-MKW+UFzJs7yoejWpHo5liaS1KdI+75lwfhgxV0DHE1yMTSsLptwbmelk/51expl7oBYEXC6Wofe4+zPTv+H8NA==
   dependencies:
     "@canonical/macaroon-bakery" "1.2.2"
     btoa "1.2.1"


### PR DESCRIPTION
## Done

- Update `js-jujulib` to the latest version so that the dashboard can work on Juju 3.0 stable release.

## QA

- Pull code
- Link to a Juju `3.0` stable (available in snapstore)
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/

## Details

Jira ticket: https://warthogs.atlassian.net/browse/WD-694

