### PR TITLE
WD-591 - Remove juju connections from the redux store

### DIFF
--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -1,8 +1,4 @@
-import {
-  getBakery,
-  getJujuAPIInstances,
-  getPingerIntervalIds,
-} from "app/selectors";
+import { getBakery, getPingerIntervalIds } from "app/selectors";
 import {
   clearControllerData,
   clearModelData,
@@ -27,7 +23,6 @@ export const actionsList = {
   storeVersion: "STORE_VERSION",
   storeVisitURL: "STORE_VISIT_URL",
   updateControllerConnection: "UPDATE_CONTROLLER_CONNECTION",
-  updateJujuAPIInstance: "UPDATE_JUJU_API_INSTANCE",
   updatePingerIntervalId: "UPDATE_PINGER_INTERVAL_ID",
 };
 
@@ -104,20 +99,6 @@ export function updateControllerConnection(wsControllerURL, conn) {
 
 /**
   @param {String} wsControllerURL The URL of the websocket connection.
-  @param {Object} juju The active Juju api instance.
-*/
-export function updateJujuAPIInstance(wsControllerURL, juju) {
-  return {
-    type: actionsList.updateJujuAPIInstance,
-    payload: {
-      wsControllerURL,
-      juju,
-    },
-  };
-}
-
-/**
-  @param {String} wsControllerURL The URL of the websocket connection.
   @param {Object} intervalId The intervalId for the request timeout.
 */
 export function updatePingerIntervalId(wsControllerURL, intervalId) {
@@ -151,12 +132,10 @@ export function logOut(store) {
     const identityProviderAvailable =
       state?.root?.config?.identityProviderAvailable;
     const bakery = getBakery(state);
-    const jujus = getJujuAPIInstances(state);
     const pingerIntervalIds = getPingerIntervalIds(state);
     bakery.storage._store.removeItem("identity");
     bakery.storage._store.removeItem("https://api.jujucharms.com/identity");
     localStorage.removeItem("additionalControllers");
-    Object.entries(jujus).forEach((juju) => juju[1].logout());
     Object.entries(pingerIntervalIds).forEach((pingerIntervalId) =>
       clearInterval(pingerIntervalId[1])
     );

--- a/src/app/root.js
+++ b/src/app/root.js
@@ -36,11 +36,6 @@ function rootReducer(state = {}, action) {
         delete draftState.controllerConnections;
         delete draftState.visitURL;
         break;
-      case actionsList.updateJujuAPIInstance:
-        const jujus = cloneDeep(state.jujus || {});
-        jujus[action.payload.wsControllerURL] = action.payload.juju;
-        draftState.jujus = jujus;
-        break;
       case actionsList.updatePingerIntervalId:
         const intervals = cloneDeep(state.pingerIntervalIds || {});
         intervals[action.payload.wsControllerURL] = action.payload.intervalId;

--- a/src/app/selectors.js
+++ b/src/app/selectors.js
@@ -63,13 +63,6 @@ export const getUserPass = (wsControllerURL, state) =>
 export const getLoginError = (state) => state?.root?.loginError;
 
 /**
-  Fetches the juju api instance from state.
-  @param {Object} state The application state.
-  @returns {Object|Null} The juju api instance or null if none found.
-*/
-export const getJujuAPIInstances = (state) => state?.root?.jujus;
-
-/**
   Fetches the pinger intervalId from state.
   @param {Object} state The application state.
   @returns {Object|Null} The pinger intervalId or null if none found.

--- a/src/components/LogIn/LogIn.tsx
+++ b/src/components/LogIn/LogIn.tsx
@@ -68,7 +68,6 @@ export default function LogIn({ children }: PropsWithChildren<ReactNode>) {
   @returns A component for the error message.
 */
 function generateErrorMessage(loginError?: string) {
-  console.log("loginError", loginError);
   if (!loginError) {
     return null;
   }

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -21,6 +21,7 @@ type Conn = {
   };
 };
 
+// TODO: Import this from jujulib once it has been migrated to TypeScript.
 type Juju = {
   logout: () => void;
 };

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -2,7 +2,6 @@ import {
   actionsList,
   storeLoginError,
   updateControllerConnection,
-  updateJujuAPIInstance,
   updatePingerIntervalId,
 } from "app/actions";
 import * as jujuModule from "juju";
@@ -20,6 +19,10 @@ type Conn = {
   info: {
     user: {};
   };
+};
+
+type Juju = {
+  logout: () => void;
 };
 
 jest.mock("juju", () => ({
@@ -40,7 +43,7 @@ describe("model poller", () => {
   const wsControllerURL = "wss://example.com";
   const controllers = [[wsControllerURL, {}, {}, false]];
   const models = [{ model: { uuid: "abc123" } }];
-  const juju = { is: "juju" };
+  let juju: Juju;
   const intervalId = 99;
   let conn: Conn;
   const storeState = {
@@ -79,6 +82,9 @@ describe("model poller", () => {
         user: {},
       },
     };
+    juju = {
+      logout: jest.fn(),
+    };
   });
 
   const runMiddleware = async (actionOverrides?: Partial<AnyAction>) => {
@@ -90,7 +96,9 @@ describe("model poller", () => {
       },
       ...(actionOverrides ?? {}),
     };
-    await modelPollerMiddleware(fakeStore)(next)(action);
+    const middleware = modelPollerMiddleware(fakeStore);
+    await middleware(next)(action);
+    return middleware;
   };
 
   afterEach(() => {
@@ -152,9 +160,6 @@ describe("model poller", () => {
     expect(next).not.toHaveBeenCalled();
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
       updateControllerConnection(wsControllerURL, conn)
-    );
-    expect(fakeStore.dispatch).toHaveBeenCalledWith(
-      updateJujuAPIInstance(wsControllerURL, juju)
     );
     expect(fakeStore.dispatch).toHaveBeenCalledWith(
       updatePingerIntervalId(wsControllerURL, intervalId)
@@ -257,7 +262,6 @@ describe("model poller", () => {
       jujuModule,
       "fetchAllModelStatuses"
     );
-    const models = [{ model: { uuid: "abc123" } }];
     jest.spyOn(jujuModule, "loginWithBakery").mockImplementation(async () => ({
       conn,
       intervalId,
@@ -271,12 +275,6 @@ describe("model poller", () => {
     // Resolve the async calls again.
     await new Promise(jest.requireActual("timers").setImmediate);
     expect(next).not.toHaveBeenCalled();
-    const updateModels = updateModelList(
-      { "user-models": models },
-      wsControllerURL
-    );
-    expect(fakeStore.dispatch).toHaveBeenNthCalledWith(4, updateModels);
-    expect(fakeStore.dispatch).toHaveBeenNthCalledWith(5, updateModels);
     expect(fetchAllModelStatuses).toHaveBeenCalledTimes(2);
   });
 
@@ -299,7 +297,6 @@ describe("model poller", () => {
       jujuModule,
       "fetchAllModelStatuses"
     );
-    const models = [{ model: { uuid: "abc123" } }];
     jest.spyOn(jujuModule, "loginWithBakery").mockImplementation(async () => ({
       conn,
       intervalId,
@@ -313,12 +310,23 @@ describe("model poller", () => {
     // Resolve the async calls again.
     await new Promise(jest.requireActual("timers").setImmediate);
     expect(next).not.toHaveBeenCalled();
-    const updateModels = updateModelList(
-      { "user-models": models },
-      wsControllerURL
-    );
-    expect(fakeStore.dispatch).toHaveBeenNthCalledWith(4, updateModels);
-    expect(fakeStore.dispatch).toHaveBeenCalledTimes(4);
     expect(fetchAllModelStatuses).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles logging out of models", async () => {
+    jest.spyOn(jujuModule, "loginWithBakery").mockImplementation(async () => ({
+      conn,
+      intervalId,
+      juju,
+    }));
+    const middleware = await runMiddleware();
+    const action = {
+      type: actionsList.logOut,
+      payload: null,
+    };
+    await middleware(next)(action);
+    expect(juju.logout).toHaveBeenCalled();
+    // The action should be passed along to the reducers.
+    expect(next).toHaveBeenCalled();
   });
 });

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -5,7 +5,6 @@ import {
   actionsList,
   storeLoginError,
   updateControllerConnection,
-  updateJujuAPIInstance,
   updatePingerIntervalId,
 } from "app/actions";
 import { isLoggedIn } from "app/selectors";
@@ -30,6 +29,8 @@ type ControllerOptions = [
 ];
 
 export const modelPollerMiddleware: Middleware = (reduxStore) => {
+  // TODO: provide the connection when the types are available from jujulib.
+  const jujus = new Map<string, TSFixMe>();
   return (next) =>
     async (
       action: PayloadAction<{
@@ -82,7 +83,7 @@ export const modelPollerMiddleware: Middleware = (reduxStore) => {
           reduxStore.dispatch(
             updateControllerConnection(wsControllerURL, conn)
           );
-          reduxStore.dispatch(updateJujuAPIInstance(wsControllerURL, juju));
+          jujus.set(wsControllerURL, juju);
           if (intervalId) {
             reduxStore.dispatch(
               updatePingerIntervalId(wsControllerURL, intervalId)
@@ -137,6 +138,10 @@ export const modelPollerMiddleware: Middleware = (reduxStore) => {
           } while (isLoggedIn(wsControllerURL, reduxStore.getState()));
         });
         return;
+      } else if (action.type === actionsList.logOut) {
+        jujus.forEach((juju) => {
+          juju.logout();
+        });
       }
       return next(action);
     };

--- a/src/testing/complete-redux-store-dump.js
+++ b/src/testing/complete-redux-store-dump.js
@@ -142,47 +142,6 @@ export default {
         }
       }
     },
-    jujus: {
-      'wss://jimm.jujucharms.com/api': {
-        _transport: {
-          _ws: {},
-          _counter: 20,
-          _callbacks: {},
-          _debug: false
-        },
-        _facades: [
-          null,
-          null,
-          null,
-          null,
-          null,
-          null,
-          null
-        ],
-        _bakery: {
-          storage: {
-            _store: {
-              'https://api.staging.jujucharms.com/identity': 'W3siYyI6W3siaSI6InRpFh1NWtPNHdNY2paeGd3MU9aTmVmWHlzIn1d',
-              identity: 'W3siYyI6W3siaSI6InRpbCV3BTcDRWLUl1UzF1SzgifV0=',
-              'https://api.jujucharms.com/identity': 'W3siYyI6W3siaSI6InRpbWUGQVpCV3BTcDRWLUl1UzF1SzgifV0='
-            },
-            _services: {},
-            _charmstoreCookieSetter: null
-          },
-          _dischargeDisabled: false
-        },
-        _admin: {
-          version: 3,
-          _transport: {
-            _ws: {},
-            _counter: 20,
-            _callbacks: {},
-            _debug: false
-          },
-          _info: {}
-        }
-      }
-    },
     pingerIntervalIds: {
       'wss://jimm.jujucharms.com/api': 18
     }


### PR DESCRIPTION
## Done

- Remove juju connections from the redux store.
- Store connections in the middleware.
- Handle logging out of models.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Open your dev tools network tab and filter by the websocket connections.
- You should see a websocket for each model.
- In the sidebar click your name and then logout.
- Each of the model websockets should close.

## Details

Fixes: https://warthogs.atlassian.net/browse/WD-591

