### PR TITLE
WD-877 - Upgrade to bakeryjs 1.3.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@canonical/jaaslib": "0.6.1",
     "@canonical/jujulib": "2.0.0-beta.8",
-    "@canonical/macaroon-bakery": "1.2.2",
+    "@canonical/macaroon-bakery": "1.3.0",
     "@canonical/react-components": "0.37.8",
     "@reduxjs/toolkit": "1.9.1",
     "@sentry/browser": "7.22.0",

--- a/src/@canonical/macaroon-bakery.d.ts
+++ b/src/@canonical/macaroon-bakery.d.ts
@@ -1,1 +1,0 @@
-declare module "@canonical/macaroon-bakery";

--- a/src/app/bakery.ts
+++ b/src/app/bakery.ts
@@ -3,14 +3,8 @@ import { Bakery, BakeryStorage } from "@canonical/macaroon-bakery";
 import { storeVisitURL } from "app/actions";
 import reduxStore from "store/store";
 
-// This type can be remove once bakeryjs has been migrated to typescript.
-export type VisitPageInfo = {
-  WaitURL: string;
-  VisitURL: string;
-};
-
 const bakery = new Bakery({
-  visitPage: (resp: { Info: VisitPageInfo }) => {
+  visitPage: (resp) => {
     reduxStore.dispatch(storeVisitURL(resp.Info.VisitURL));
   },
   storage: new BakeryStorage(localStorage, {}),

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -23,7 +23,7 @@ export enum LoginError {
   NO_INFO = "Unable to retrieve controller details",
 }
 
-// TODO: provide these types when the types are available from bakeryjs.
+// TODO: provide these types when the types are available from jujulib.
 // TODO: Import bakery instead of passing it as a param.
 type ControllerOptions = [
   string,
@@ -123,7 +123,7 @@ export const modelPollerMiddleware: Middleware = (reduxStore) => {
               });
               reduxStore.dispatch(updateModelList(models, wsControllerURL));
               // TODO: this error should not be cast once the types are
-              // available from bakeryjs.
+              // available from jujulib.
               const modelUUIDList = models["user-models"].map(
                 (item: TSFixMe) => item.model.uuid
               );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1114,6 +1114,13 @@
   dependencies:
     macaroon "3.0.4"
 
+"@canonical/macaroon-bakery@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@canonical/macaroon-bakery/-/macaroon-bakery-1.3.0.tgz#9ef021733b5564d64929d3f82f36351cd7b1dd1e"
+  integrity sha512-gDv+ScuBxMgQQREHj0s2JdNxni/FJtzvyTUEnJoboISWC3gh6tpou2AlsUaU4dQCNwlbJn2dbDecv2gu7GopMA==
+  dependencies:
+    macaroon "3.0.4"
+
 "@canonical/react-components@0.37.8":
   version "0.37.8"
   resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-0.37.8.tgz#69fceb80a299737dbe864a5b50eeee766f78717b"


### PR DESCRIPTION
## Done

- Upgrade bakeryjs to 1.3.0.
- Remove placeholder definition file.
- Remove types that are now provided by bakeryjs.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Check that the UI loads as normal.

## Details

Fixes: https://warthogs.atlassian.net/browse/WD-877
