### PR TITLE
WD-922 - Handle updating model permissions

### DIFF
--- a/src/app/action-types.ts
+++ b/src/app/action-types.ts
@@ -2,4 +2,5 @@
 export const actionsList = {
   logOut: "LOG_OUT",
   connectAndPollControllers: "CONNECT_AND_POLL_CONTROLLERS",
+  updatePermissions: "UPDATE_PERMISSIONS",
 };

--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -16,6 +16,25 @@ import {
 
 import { actionsList } from "./action-types";
 
+export const updatePermissions = (
+  wsControllerURL,
+  modelUUID,
+  user,
+  permissionTo,
+  permissionFrom,
+  action
+) => ({
+  type: actionsList.updatePermissions,
+  payload: {
+    action,
+    modelUUID,
+    permissionFrom,
+    permissionTo,
+    user,
+    wsControllerURL,
+  },
+});
+
 // Thunks
 /**
   Flush bakery from redux store

--- a/src/store/middleware/check-auth.js
+++ b/src/store/middleware/check-auth.js
@@ -71,8 +71,7 @@ export default ({ getState }) =>
         checkLoggedIn(state, wsControllerURL)
       ) {
         // Await the next to support async thunks
-        await next(action);
-        return;
+        return await next(action);
       } else {
         error(action.NAME, wsControllerURL);
       }
@@ -81,8 +80,7 @@ export default ({ getState }) =>
         actionAllowlist.includes(action.type) ||
         checkLoggedIn(state, wsControllerURL)
       ) {
-        next(action);
-        return;
+        return next(action);
       } else {
         error(action.type, wsControllerURL);
       }

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,5 +1,10 @@
-import { configureStore } from "@reduxjs/toolkit";
-import { useStore } from "react-redux";
+import { AnyAction, configureStore } from "@reduxjs/toolkit";
+import {
+  TypedUseSelectorHook,
+  useDispatch,
+  useSelector,
+  useStore,
+} from "react-redux";
 
 import generalReducer from "store/general";
 import checkAuth from "store/middleware/check-auth";
@@ -37,8 +42,20 @@ export type RootState = {
   ui: UIState;
 };
 
-export const useAppStore = useStore<RootState>;
-
 export type Store = typeof store;
+export type AppDispatch = typeof store.dispatch;
+export const useAppStore = useStore<RootState>;
+// This hook can be used in place of useDispatch to get correctly typed dispatches using thunks or
+// action objects as suggested by the docs:
+// https://redux-toolkit.js.org/usage/usage-with-typescript#correct-typings-for-the-dispatch-type
+export const useAppDispatch: () => AppDispatch = useDispatch;
+// This hook can be used in place of useDispatch to get correctly typed dispatches that return promises.
+export const usePromiseDispatch = () => {
+  const dispatch = useAppDispatch();
+  return <Result>(action: AnyAction) =>
+    (dispatch as (action: AnyAction) => Promise<Result>)(action);
+};
+// This hook annotates the selectors using the store state.
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
 export default store;


### PR DESCRIPTION
## Done

Support updating model permissions in the model poller middleware.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Open the list of models.
- Click the "Access" button for one of the models.
- Enter a username for a real user and click "Add user" and you should get a notification that the user was added and they should appear in the list of users.
- Now enter an incorrect username and click "Add user" and you should get an error.

[WD-922]: https://warthogs.atlassian.net/browse/WD-922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ