### PR TITLE
Upgrade jujulib

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@canonical/jaaslib": "0.6.1",
-    "@canonical/jujulib": "3.0.2",
+    "@canonical/jujulib": "3.1.0",
     "@canonical/macaroon-bakery": "1.3.2",
     "@canonical/react-components": "0.38.0",
     "@reduxjs/toolkit": "1.9.1",

--- a/src/pages/ModelDetails/ModelDetails.tsx
+++ b/src/pages/ModelDetails/ModelDetails.tsx
@@ -27,11 +27,10 @@ export default function ModelDetails() {
     let watcherHandle: TSFixMe = null;
 
     async function loadFullData() {
-      ({ conn, watcherHandle, pingerIntervalId } = await startModelWatcher(
-        modelUUID,
-        appState,
-        dispatch
-      ));
+      const response = await startModelWatcher(modelUUID, appState, dispatch);
+      conn = response?.conn ?? null;
+      watcherHandle = response?.watcherHandle ?? null;
+      pingerIntervalId = response?.pingerIntervalId ?? null;
       // Fetch the missing model status data. This data should eventually make
       // its way into the all watcher at which point we can drop this additional
       // request for data.

--- a/src/store/general/reducers.test.ts
+++ b/src/store/general/reducers.test.ts
@@ -16,7 +16,7 @@ describe("reducers", () => {
   it("updateControllerConnection", () => {
     const state = generalStateFactory.build({
       controllerConnections: {
-        "wss://example.com": "default info",
+        "wss://example.com": { controllerTag: "default-info" },
       },
     });
     expect(
@@ -24,13 +24,13 @@ describe("reducers", () => {
         state,
         actions.updateControllerConnection({
           wsControllerURL: "wss://example.com",
-          info: "new info",
+          info: { controllerTag: "new-info" },
         })
       )
     ).toStrictEqual({
       ...state,
       controllerConnections: {
-        "wss://example.com": "new info",
+        "wss://example.com": { controllerTag: "new-info" },
       },
     });
   });
@@ -100,7 +100,7 @@ describe("reducers", () => {
   it("logOut", () => {
     const state = generalStateFactory.build({
       controllerConnections: {
-        "wss://example.com": "default info",
+        "wss://example.com": { controllerTag: "default-info" },
       },
       visitURL: "/visit",
     });

--- a/src/store/general/selectors.test.ts
+++ b/src/store/general/selectors.test.ts
@@ -90,7 +90,7 @@ describe("selectors", () => {
 
   it("getControllerConnections", () => {
     const controllerConnections = {
-      "wss://example.com": "connection",
+      "wss://example.com": { controllerTag: "controller" },
     };
     expect(
       getControllerConnections(
@@ -105,7 +105,7 @@ describe("selectors", () => {
 
   it("getControllerConnection", () => {
     const controllerConnections = {
-      "wss://example.com": "connection",
+      "wss://example.com": { controllerTag: "controller" },
     };
     expect(
       getControllerConnection(
@@ -116,7 +116,7 @@ describe("selectors", () => {
         }),
         "wss://example.com"
       )
-    ).toBe("connection");
+    ).toStrictEqual({ controllerTag: "controller" });
   });
 
   it("isConnecting", () => {

--- a/src/store/general/selectors.ts
+++ b/src/store/general/selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 
 import { RootState } from "store/store";
+import { TSFixMe } from "types";
 
 const slice = (state: RootState) => state.general;
 
@@ -82,7 +83,9 @@ export const getActiveUserTag = createSelector(
     slice,
     (state, wsControllerURL) => getControllerConnection(state, wsControllerURL),
   ],
-  (_sliceState, controllerConnection) => controllerConnection?.user.identity
+  (_sliceState, controllerConnection) =>
+    // TSFixMe: jujulib types user as `object`.
+    (controllerConnection?.user as TSFixMe)?.identity
 );
 
 /**

--- a/src/store/general/types.ts
+++ b/src/store/general/types.ts
@@ -1,4 +1,4 @@
-import { TSFixMe } from "types";
+import { ConnectionInfo } from "@canonical/jujulib";
 
 export type Config = {
   controllerAPIEndpoint: string;
@@ -10,9 +10,7 @@ export type Config = {
   isJuju: boolean;
 };
 
-// TSFixMe: This should use the ConnectionInfo type once it has been exported
-// from jujulib.
-export type ControllerConnections = Record<string, TSFixMe>;
+export type ControllerConnections = Record<string, ConnectionInfo>;
 
 export type PingerIntervalIds = Record<string, number>;
 

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -15,7 +15,7 @@ export type Controller = {
   path: string;
   Public?: boolean;
   uuid: string;
-  version: string;
+  version?: string;
 };
 
 export type AdditionalController = {

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -14,20 +14,15 @@ import {
 import { actions as jujuActions } from "store/juju";
 import { TSFixMe } from "@canonical/react-components";
 import { RootState, Store } from "store/store";
+import { Client, Connection } from "@canonical/jujulib";
+import { Credential } from "store/general/types";
 
 export enum LoginError {
   LOG = "unable to log into controller",
   NO_INFO = "Unable to retrieve controller details",
 }
 
-// TODO: provide these types when the types are available from jujulib.
-type ControllerOptions = [string, TSFixMe, boolean, boolean | undefined];
-
-// TSFixMe: substitute for the connection type when it is available from jujulib.
-type Connection = TSFixMe;
-
-// TSFixMe: substitute for the juju client type when it is available from jujulib.
-type Client = TSFixMe;
+type ControllerOptions = [string, Credential, boolean, boolean | undefined];
 
 export const modelPollerMiddleware: Middleware<
   {},
@@ -35,7 +30,6 @@ export const modelPollerMiddleware: Middleware<
   Store["dispatch"]
 > = (reduxStore) => {
   const controllers = new Map<string, Connection>();
-  // TSFixMe: substitute the connection type when it is available from jujulib.
   const jujus = new Map<string, Client>();
   return (next) => async (action) => {
     if (action.type === appActions.connectAndPollControllers.type) {
@@ -49,10 +43,8 @@ export const modelPollerMiddleware: Middleware<
           ] = controllerData;
           let conn: Connection;
           let juju: Client;
-          // TSFixMe: substitute the correct types once available from jujlib
-          // and once src/juju/index.js has been migrated to TypeScript.
-          let error: TSFixMe;
-          let intervalId: TSFixMe;
+          let error: unknown;
+          let intervalId: number | undefined;
           try {
             ({ conn, error, juju, intervalId } = await loginWithBakery(
               wsControllerURL,
@@ -60,12 +52,8 @@ export const modelPollerMiddleware: Middleware<
               identityProviderAvailable
             ));
             controllers.set(wsControllerURL, conn);
-            if (error) {
-              // TODO: this error should not be cast once loginWithBakery has
-              // been migrated to TypeScript.
-              reduxStore.dispatch(
-                generalActions.storeLoginError(error as string)
-              );
+            if (error && typeof error === "string") {
+              reduxStore.dispatch(generalActions.storeLoginError(error));
               return;
             }
           } catch (e) {
@@ -132,7 +120,8 @@ export const modelPollerMiddleware: Middleware<
           do {
             try {
               const models = await conn.facades.modelManager.listModels({
-                tag: conn.info.user.identity,
+                // TSFixMe: jujulib types user as `object`.
+                tag: (conn.info.user as TSFixMe).identity,
               });
               reduxStore.dispatch(
                 jujuActions.updateModelList({ models, wsControllerURL })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,12 +1092,12 @@
   resolved "https://registry.yarnpkg.com/@canonical/jaaslib/-/jaaslib-0.6.1.tgz#11eb43ba05e6e0c69e44a6947bd66fa1397ecefb"
   integrity sha512-Ts7TziwN3ZkB7bNpAnPoiSJQaDr9becHHx5AXaTl1uq/WKvscO0vtoa1QsBtksh5QMMuFlWn3Z2PmnfT4IVwmg==
 
-"@canonical/jujulib@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@canonical/jujulib/-/jujulib-3.0.2.tgz#2e923b13fe3a494b5232a1f4676f9b0f3a9b0a1b"
-  integrity sha512-z88x5uDzeDq1x0ohR/q8/p+69ts7UuIqeiobpWjhuwGFWYiyEFiGpJnTUFxH6shegeumd6ra9fesoE3s7rI/YA==
+"@canonical/jujulib@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@canonical/jujulib/-/jujulib-3.1.0.tgz#1d027f5dbb561ebcf07310701ce63e18c77f1920"
+  integrity sha512-+BLL6scInNODTRDhUu94If0fsMGR6pCxQZY9jLQq7h/0457CIzDsp1iq2nb3ceNzSlmmAu1dINu3qkLnbtsQaA==
   dependencies:
-    "@canonical/macaroon-bakery" "1.2.2"
+    "@canonical/macaroon-bakery" "1.3.2"
     btoa "1.2.1"
     websocket "1.0.34"
     xhr2 "0.2.1"
@@ -1106,13 +1106,6 @@
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@canonical/latest-news/-/latest-news-1.4.1.tgz#dcdd445ac2268a54cf60f2f8c725b6bdeb285d71"
   integrity sha512-lwrikCj0Y11X8Ln8D+elp6Ri3mYjMjsAOJtadNEFzhBrgmg8TVGYJjOdwy8TvRaxy7fHnvVajIKAYWX44Tfj6w==
-
-"@canonical/macaroon-bakery@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@canonical/macaroon-bakery/-/macaroon-bakery-1.2.2.tgz#bba6ff4f9212f0a3c301edfb7af864ff9b9773ee"
-  integrity sha512-wiY9L4DMdff8uLgrABKzQVUQy92mYVApz2ffpvRdNw/G0U9p3H7HouIEQsWHQwSKJC+gLIT/fE5o+hUDoF5Ixw==
-  dependencies:
-    macaroon "3.0.4"
 
 "@canonical/macaroon-bakery@1.3.2":
   version "1.3.2"


### PR DESCRIPTION
## Done

- Upgrade jujulib to 3.1.0
- Replace local types with newly exposed types from jujulib.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Check that you can still list controllers and models as before.
