### PR TITLE
WD-2030 - Replace controller test data with factories

### DIFF
--- a/src/components/ModelTableList/CloudGroup.test.tsx
+++ b/src/components/ModelTableList/CloudGroup.test.tsx
@@ -6,6 +6,7 @@ import { QueryParamProvider } from "use-query-params";
 import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import { rootStateFactory } from "testing/factories/root";
+import { generalStateFactory, configFactory } from "testing/factories/general";
 
 import CloudGroup from "./CloudGroup";
 
@@ -72,7 +73,26 @@ describe("CloudGroup", () => {
   });
 
   it("model access buttons are present in cloud group", () => {
-    const store = mockStore(dataDump);
+    const store = mockStore(
+      rootStateFactory.build({
+        general: generalStateFactory.build({
+          config: configFactory.build({
+            controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
+          }),
+          controllerConnections: {
+            "wss://jimm.jujucharms.com/api": {
+              user: {
+                "display-name": "eggman",
+                identity: "user-eggman@external",
+                "controller-access": "",
+                "model-access": "",
+              },
+            },
+          },
+        }),
+        juju: dataDump.juju,
+      })
+    );
     const filters = {
       cloud: ["aws"],
     };

--- a/src/components/ModelTableList/ModelTableList.test.tsx
+++ b/src/components/ModelTableList/ModelTableList.test.tsx
@@ -7,8 +7,10 @@ import { QueryParamProvider } from "use-query-params";
 import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import * as appSelectors from "store/juju/selectors";
-import ModelTableList from "./ModelTableList";
+import { controllerFactory } from "testing/factories/juju/juju";
+import { rootStateFactory } from "testing/factories/root";
 
+import ModelTableList from "./ModelTableList";
 import dataDump from "../../testing/complete-redux-store-dump";
 import { TestId as CloudTestId } from "./CloudGroup";
 import { TestId as OwnerTestId } from "./OwnerGroup";
@@ -142,9 +144,24 @@ describe("ModelTableList", () => {
     // override existing data mock while using as much real content as possible.
     const knownUUID = "086f0bf8-da79-4ad4-8d73-890721332c8b";
     const testModelUUID = "19b56b55-6373-4286-8c19-957fakee8469";
-    clonedData.juju.modelData[testModelUUID].info["controller-uuid"] =
-      knownUUID;
-    const store = mockStore(clonedData);
+    const state = rootStateFactory.build({
+      juju: {
+        ...clonedData.juju,
+        controllers: {
+          "wss://jimm.jujucharms.com/api": [
+            controllerFactory.build({
+              path: "admins/1-eu-west-1-aws-jaas",
+              uuid: knownUUID,
+            }),
+          ],
+        },
+      },
+    });
+    const modelDataInfo = state.juju.modelData?.[testModelUUID].info;
+    if (modelDataInfo) {
+      modelDataInfo["controller-uuid"] = knownUUID;
+    }
+    const store = mockStore(state);
     render(
       <MemoryRouter>
         <Provider store={store}>

--- a/src/components/ModelTableList/OwnerGroup.test.tsx
+++ b/src/components/ModelTableList/OwnerGroup.test.tsx
@@ -6,6 +6,7 @@ import { QueryParamProvider } from "use-query-params";
 import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import { rootStateFactory } from "testing/factories/root";
+import { generalStateFactory, configFactory } from "testing/factories/general";
 
 import OwnerGroup from "./OwnerGroup";
 
@@ -72,7 +73,26 @@ describe("OwnerGroup", () => {
   });
 
   it("model access buttons are present in owners group", () => {
-    const store = mockStore(dataDump);
+    const store = mockStore(
+      rootStateFactory.build({
+        general: generalStateFactory.build({
+          config: configFactory.build({
+            controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
+          }),
+          controllerConnections: {
+            "wss://jimm.jujucharms.com/api": {
+              user: {
+                "display-name": "eggman",
+                identity: "user-eggman@external",
+                "controller-access": "",
+                "model-access": "",
+              },
+            },
+          },
+        }),
+        juju: dataDump.juju,
+      })
+    );
     const filters = {
       cloud: ["aws"],
     };

--- a/src/components/ModelTableList/StatusGroup.test.tsx
+++ b/src/components/ModelTableList/StatusGroup.test.tsx
@@ -6,6 +6,7 @@ import { QueryParamProvider } from "use-query-params";
 import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import { rootStateFactory } from "testing/factories";
+import { generalStateFactory, configFactory } from "testing/factories/general";
 
 import StatusGroup from "./StatusGroup";
 
@@ -88,7 +89,26 @@ describe("StatusGroup", () => {
   });
 
   it("model access buttons are present in status group", () => {
-    const store = mockStore(dataDump);
+    const store = mockStore(
+      rootStateFactory.build({
+        general: generalStateFactory.build({
+          config: configFactory.build({
+            controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
+          }),
+          controllerConnections: {
+            "wss://jimm.jujucharms.com/api": {
+              user: {
+                "display-name": "eggman",
+                identity: "user-eggman@external",
+                "controller-access": "",
+                "model-access": "",
+              },
+            },
+          },
+        }),
+        juju: dataDump.juju,
+      })
+    );
     const filters = {
       cloud: ["aws"],
     };

--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -26,7 +26,10 @@ describe("Primary Nav", () => {
   });
 
   it("displays correct number of blocked models", () => {
-    const store = mockStore(dataDump);
+    const state = rootStateFactory.withGeneralConfig().build({
+      juju: dataDump.juju,
+    });
+    const store = mockStore(state);
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>

--- a/src/pages/ControllersIndex/ControllersIndex.test.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.test.tsx
@@ -6,7 +6,12 @@ import configureStore from "redux-mock-store";
 import { QueryParamProvider } from "use-query-params";
 import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
+import type { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories/root";
+import {
+  controllerFactory,
+  jujuStateFactory,
+} from "testing/factories/juju/juju";
 
 import ControllersIndex from "./ControllersIndex";
 
@@ -15,18 +20,14 @@ import dataDump from "../../testing/complete-redux-store-dump";
 const mockStore = configureStore([]);
 
 describe("Controllers table", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory.withGeneralConfig().build();
+  });
+
   it("renders a blank page if no data", () => {
-    const store = mockStore(
-      rootStateFactory.build({
-        juju: {},
-        general: {
-          config: {},
-        },
-        ui: {
-          userMenuActive: false,
-        },
-      })
-    );
+    const store = mockStore(state);
     render(
       <MemoryRouter>
         <Provider store={store}>
@@ -38,8 +39,17 @@ describe("Controllers table", () => {
     );
     expect(screen.queryByRole("row")).not.toBeInTheDocument();
   });
+
   it("renders the correct number of rows", () => {
-    const store = mockStore(dataDump);
+    state.juju = jujuStateFactory.build({
+      controllers: {
+        "wss://jimm.jujucharms.com/api": [
+          controllerFactory.build({ path: "admin/jaas", uuid: "123" }),
+          controllerFactory.build({ path: "admin/jaas2", uuid: "456" }),
+        ],
+      },
+    });
+    const store = mockStore(state);
     render(
       <MemoryRouter>
         <Provider store={store}>
@@ -51,9 +61,19 @@ describe("Controllers table", () => {
     );
     expect(screen.getAllByRole("row")).toHaveLength(3);
   });
+
   it("counts models, machines, apps, and units", () => {
     const clonedData = cloneDeep(dataDump);
-    const store = mockStore(clonedData);
+    state.juju = {
+      ...clonedData.juju,
+      controllers: {
+        "wss://jimm.jujucharms.com/api": [
+          controllerFactory.build({ path: "admin/jaas", uuid: "123" }),
+          controllerFactory.build({ path: "admin/jaas2", uuid: "456" }),
+        ],
+      },
+    };
+    const store = mockStore(state);
     render(
       <MemoryRouter>
         <Provider store={store}>
@@ -65,9 +85,9 @@ describe("Controllers table", () => {
     );
     expect(screen.getAllByRole("row")[1]).toMatchSnapshot();
   });
+
   it("shows 'Register new controller' panel", () => {
-    const clonedData = cloneDeep(dataDump);
-    const store = mockStore(clonedData);
+    const store = mockStore(state);
     render(
       <Provider store={store}>
         <MemoryRouter

--- a/src/pages/ControllersIndex/__snapshots__/ControllersIndex.test.tsx.snap
+++ b/src/pages/ControllersIndex/__snapshots__/ControllersIndex.test.tsx.snap
@@ -23,42 +23,40 @@ exports[`Controllers table counts models, machines, apps, and units 1`] = `
     class="u-align--right"
     role="gridcell"
   >
-    16
+    0
   </td>
   <td
     aria-hidden="false"
     class="u-align--right"
     role="gridcell"
   >
-    50
+    0
   </td>
   <td
     aria-hidden="false"
     class="u-align--right"
     role="gridcell"
   >
-    66
+    0
   </td>
   <td
     aria-hidden="false"
     class="u-align--right"
     role="gridcell"
   >
-    51
+    0
   </td>
   <td
     aria-hidden="false"
     class="u-align--right"
     role="gridcell"
-  >
-    2.8.3
-  </td>
+  />
   <td
     aria-hidden="false"
     class="u-align--right u-capitalise"
     role="gridcell"
   >
-    true
+    False
   </td>
 </tr>
 `;

--- a/src/pages/ModelsIndex/ModelsIndex.test.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.test.tsx
@@ -7,13 +7,24 @@ import dataDump from "testing/complete-redux-store-dump";
 import { QueryParamProvider } from "use-query-params";
 import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
+import { rootStateFactory } from "testing/factories/root";
+import { RootState } from "store/store";
+
 import ModelsIndex from "./ModelsIndex";
 
 const mockStore = configureStore([]);
 
 describe("Models Index page", () => {
+  let state: RootState;
+
+  beforeEach(() => {
+    state = rootStateFactory.withGeneralConfig().build({
+      juju: dataDump.juju,
+    });
+  });
+
   it("renders without crashing", () => {
-    const store = mockStore(dataDump);
+    const store = mockStore(state);
     render(
       <Provider store={store}>
         <MemoryRouter>
@@ -29,7 +40,7 @@ describe("Models Index page", () => {
   });
 
   it("displays correct grouping view", async () => {
-    const store = mockStore(dataDump);
+    const store = mockStore(state);
     render(
       <Provider store={store}>
         <BrowserRouter>
@@ -52,7 +63,7 @@ describe("Models Index page", () => {
   });
 
   it("should display the correct window title", () => {
-    const store = mockStore(dataDump);
+    const store = mockStore(state);
     render(
       <Provider store={store}>
         <BrowserRouter>

--- a/src/store/app/thunks.test.ts
+++ b/src/store/app/thunks.test.ts
@@ -7,6 +7,10 @@ import {
   generalStateFactory,
   configFactory,
 } from "testing/factories/general";
+import {
+  additionalControllerFactory,
+  controllerFactory,
+} from "testing/factories/juju/juju";
 
 import { ControllerArgs } from "./actions";
 import { logOut, connectAndStartPolling, connectAndListModels } from "./thunks";
@@ -62,9 +66,6 @@ describe("thunks", () => {
     const dispatch = jest.fn();
     const getState = jest.fn(() => rootStateFactory.build());
     await action(dispatch, getState, null);
-    // expect(dispatch).toHaveBeenCalledWith(
-    //   connectAndListModels([additionalController])
-    // );
     expect(dispatch).toHaveBeenCalledWith(
       generalActions.storeUserPass({
         wsControllerURL: additionalController[0],
@@ -74,7 +75,7 @@ describe("thunks", () => {
     expect(dispatch).toHaveBeenCalledWith(
       jujuActions.updateControllerList({
         wsControllerURL: additionalController[0],
-        controllers: [{ additionalController: true }],
+        controllers: [additionalControllerFactory.build()],
       })
     );
     localStorage.removeItem("additionalControllers");
@@ -110,11 +111,11 @@ describe("thunks", () => {
         juju: {
           controllers: {
             "wss://example.com": [
-              {
+              controllerFactory.build({
                 path: "/",
                 uuid: "uuid123",
                 version: "1",
-              },
+              }),
             ],
           },
         },

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -1,6 +1,10 @@
+import { DeltaEntityTypes, DeltaChangeTypes } from "juju/types";
+import {
+  controllerFactory,
+  modelWatcherDataFactory,
+} from "testing/factories/juju/juju";
+
 import { actions, reducer } from "./slice";
-import { modelWatcherDataFactory } from "../../testing/factories/juju/juju";
-import { DeltaEntityTypes, DeltaChangeTypes } from "../../juju/types";
 
 const defaultState = {
   controllers: null,
@@ -201,13 +205,7 @@ describe("reducers", () => {
     const state = {
       ...defaultState,
       controllers: {
-        "wss://example.com": [
-          {
-            path: "/",
-            uuid: "abc123",
-            version: "1",
-          },
-        ],
+        "wss://example.com": [controllerFactory.build()],
       },
     };
     expect(reducer(state, actions.clearControllerData())).toStrictEqual({
@@ -218,13 +216,7 @@ describe("reducers", () => {
 
   it("updateControllerList", () => {
     const state = defaultState;
-    const controllers = [
-      {
-        path: "/",
-        uuid: "abc123",
-        version: "1",
-      },
-    ];
+    const controllers = [controllerFactory.build()];
     expect(
       reducer(
         state,

--- a/src/store/juju/thunks.test.ts
+++ b/src/store/juju/thunks.test.ts
@@ -3,9 +3,11 @@ import {
   credentialFactory,
   generalStateFactory,
 } from "testing/factories/general";
+import { controllerFactory } from "testing/factories/juju/juju";
 
 import { addControllerCloudRegion } from "./thunks";
 import { actions } from "./slice";
+import { controllerLocationFactory } from "../../testing/factories/juju/juju";
 
 // Prevent setting up the bakery instance.
 jest.mock("juju/bakery");
@@ -80,11 +82,9 @@ describe("thunks", () => {
         juju: {
           controllers: {
             "wss://example.com": [
-              {
-                path: "/",
+              controllerFactory.build({
                 uuid: "uuid123",
-                version: "1",
-              },
+              }),
             ],
           },
         },
@@ -94,15 +94,13 @@ describe("thunks", () => {
     expect(dispatch).toHaveBeenCalledWith(
       actions.updateControllerList({
         controllers: [
-          {
-            path: "/",
+          controllerFactory.build({
             uuid: "uuid123",
-            version: "1",
-            location: {
+            location: controllerLocationFactory.build({
               cloud: "west",
               region: "aws",
-            },
-          },
+            }),
+          }),
         ],
         wsControllerURL: "wss://example.com",
       })
@@ -120,13 +118,7 @@ describe("thunks", () => {
         general: {},
         juju: {
           controllers: {
-            "wss://example.com": [
-              {
-                path: "/",
-                uuid: "uuid123",
-                version: "1",
-              },
-            ],
+            "wss://example.com": [controllerFactory.build()],
           },
         },
       })

--- a/src/store/middleware/model-poller.test.ts
+++ b/src/store/middleware/model-poller.test.ts
@@ -7,6 +7,7 @@ import { ControllerArgs } from "store/app/actions";
 import { actions as generalActions } from "store/general";
 import { rootStateFactory } from "testing/factories";
 import { generalStateFactory } from "testing/factories/general";
+import { controllerFactory } from "testing/factories/juju/juju";
 
 import { modelPollerMiddleware, LoginError } from "./model-poller";
 
@@ -63,13 +64,7 @@ describe("model poller", () => {
   const storeState = rootStateFactory.build({
     juju: {
       controllers: {
-        [wsControllerURL]: [
-          {
-            path: "/",
-            uuid: "abc123",
-            version: "1.0",
-          },
-        ],
+        [wsControllerURL]: [controllerFactory.build()],
       },
     },
     general: {

--- a/src/testing/complete-redux-store-dump.js
+++ b/src/testing/complete-redux-store-dump.js
@@ -1,35 +1,7 @@
 /* eslint-disable */
-// Internally consistent mock data.
-// When generating additional mock data make sure that it's internally consistent
-// across the top level keys.
+// This file has been modified to only contain data that hasn't been replaced by factories.
 
 export default {
-  general: {
-    config: {
-      controllerAPIEndpoint: 'wss://jimm.jujucharms.com/api',
-      baseAppURL: '/',
-      identityProviderAvailable: true,
-      isJuju: false,
-      showWebCLI: false
-    },
-    appVersion: '0.4.0',
-    controllerConnections: {
-      'wss://jimm.jujucharms.com/api': {
-        controllerTag: 'controller-a030379a-940f-4760-8fcf-3062b41a04e7',
-        serverVersion: '2.8.3',
-        user: {
-          'display-name': 'eggman',
-          identity: 'user-eggman@external',
-          'controller-access': '',
-          'model-access': '',
-          "model-tag": ''
-        }
-      }
-    },
-    pingerIntervalIds: {
-      'wss://jimm.jujucharms.com/api': 18
-    }
-  },
   juju: {
     models: {
       '84e872ff-9171-46be-829b-70f0ffake18d': {
@@ -11021,28 +10993,5 @@ export default {
         'remote-applications': {},
       }
     },
-    controllers: {
-      'wss://jimm.jujucharms.com/api': [
-        {
-          path: 'admin/jaas',
-          Public: true,
-          uuid: 'a030379a-940f-4760-8fcf-3062b41a04e7',
-          version: '2.8.3'
-        },
-        {
-          path: 'admins/1-eu-west-1-aws-jaas',
-          location: {
-            cloud: 'aws',
-            region: 'eu-west-1'
-          },
-          Public: true,
-          uuid: '086f0bf8-da79-4ad4-8d73-890721332c8b',
-          version: '2.6.10'
-        },
-      ]
-    }
   },
-  ui: {
-    userMenuActive: false
-  }
 }

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -1,7 +1,13 @@
 import { Factory } from "fishery";
 
-import type { JujuState, ModelsList } from "store/juju/types";
+import type {
+  AdditionalController,
+  Controller,
+  JujuState,
+  ModelsList,
+} from "store/juju/types";
 import type { ModelWatcherData } from "juju/types";
+import { ControllerLocation } from "../../../store/juju/types";
 
 interface ModelData {
   name: string;
@@ -18,6 +24,23 @@ function generateUUID() {
     return v.toString(16);
   });
 }
+
+export const additionalControllerFactory = Factory.define<AdditionalController>(
+  () => ({
+    additionalController: true,
+  })
+);
+
+export const controllerLocationFactory = Factory.define<ControllerLocation>(
+  () => ({
+    region: "aws",
+  })
+);
+
+export const controllerFactory = Factory.define<Controller>(() => ({
+  path: "admin/jaas",
+  uuid: "a030379a-940f-4760-8fcf-3062b41a04e7",
+}));
 
 export const jujuStateFactory = Factory.define<
   JujuState,


### PR DESCRIPTION
## Done

- Add controller factories.
- Update tests to use factories instead of data dump.
- Removed unused test data.

## Details

https://warthogs.atlassian.net/browse/WD-2030