### PR TITLE
Fix logout

### DIFF
--- a/src/components/LogIn/LogIn.tsx
+++ b/src/components/LogIn/LogIn.tsx
@@ -114,6 +114,7 @@ function UserPassForm() {
     const elements = e.currentTarget.elements;
     const user = elements.username.value;
     const password = elements.password.value;
+    dispatch(generalActions.cleanupLoginErrors());
     dispatch(
       generalActions.storeUserPass({
         wsControllerURL: getWSControllerURL(store.getState()),

--- a/src/store/app/thunks.test.ts
+++ b/src/store/app/thunks.test.ts
@@ -32,7 +32,8 @@ describe("thunks", () => {
     await action(dispatch, getState, null);
     expect(dispatch).toHaveBeenCalledWith(jujuActions.clearModelData());
     expect(dispatch).toHaveBeenCalledWith(jujuActions.clearControllerData());
-    const dispatchedThunk = await dispatch.mock.calls[3][0](
+    expect(dispatch).toHaveBeenCalledWith(generalActions.logOut());
+    const dispatchedThunk = await dispatch.mock.calls[4][0](
       dispatch,
       getState,
       null

--- a/src/store/app/thunks.ts
+++ b/src/store/app/thunks.ts
@@ -33,6 +33,7 @@ export const logOut = createAsyncThunk<
   );
   thunkAPI.dispatch(jujuActions.clearModelData());
   thunkAPI.dispatch(jujuActions.clearControllerData());
+  thunkAPI.dispatch(generalActions.logOut());
   if (identityProviderAvailable) {
     // To enable users to log back in after logging out we have to re-connect
     // to the controller to get another wait url and start polling on it

--- a/src/store/general/actions.test.ts
+++ b/src/store/general/actions.test.ts
@@ -1,6 +1,13 @@
 import { actions } from "./slice";
 
 describe("actions", () => {
+  it("cleanupLoginErrors", () => {
+    expect(actions.cleanupLoginErrors()).toStrictEqual({
+      type: "general/cleanupLoginErrors",
+      payload: undefined,
+    });
+  });
+
   it("updateControllerConnection", () => {
     expect(
       actions.updateControllerConnection({

--- a/src/store/general/reducers.test.ts
+++ b/src/store/general/reducers.test.ts
@@ -111,6 +111,16 @@ describe("reducers", () => {
     });
   });
 
+  it("cleanupLoginErrors", () => {
+    const state = generalStateFactory.build({
+      loginError: "Uh oh!",
+    });
+    expect(reducer(state, actions.cleanupLoginErrors())).toStrictEqual({
+      ...state,
+      loginError: null,
+    });
+  });
+
   it("updatePingerIntervalId", () => {
     const state = generalStateFactory.build({
       pingerIntervalIds: {

--- a/src/store/general/slice.ts
+++ b/src/store/general/slice.ts
@@ -13,6 +13,9 @@ const slice = createSlice({
     visitURL: null,
   } as GeneralState,
   reducers: {
+    cleanupLoginErrors: (state) => {
+      state.loginError = null;
+    },
     updateControllerConnection: (state, action) => {
       const connections = state.controllerConnections ?? {};
       connections[action.payload.wsControllerURL] = action.payload.info;
@@ -37,6 +40,8 @@ const slice = createSlice({
     },
     logOut: (state) => {
       state.controllerConnections = null;
+      state.credentials = null;
+      state.pingerIntervalIds = null;
       state.visitURL = null;
     },
     updatePingerIntervalId: (state, action) => {

--- a/src/store/middleware/check-auth.ts
+++ b/src/store/middleware/check-auth.ts
@@ -48,6 +48,8 @@ export const checkAuthMiddleware: Middleware<
     // These lists need to be generated at run time to prevent circular imports.
     const actionAllowlist = [
       appActions.connectAndPollControllers.type,
+      generalActions.cleanupLoginErrors.type,
+      generalActions.logOut.type,
       generalActions.storeConfig.type,
       generalActions.storeLoginError.type,
       generalActions.storeUserPass.type,


### PR DESCRIPTION
## Done

- Fix logout so that login reappears.
- Clean up login errors.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Log out.
- Enter some incorrect credentials and submit the form.
- You should see login errors.
- Enter correct credentials and submit. You should get logged in.
- Click the logout link in the sidebar.
- You should see the login form and there shouldn't be any errors shown.

## Details

#1353.