### PR TITLE
Missing/empty models

### DIFF
--- a/src/pages/EntityDetails/EntityDetails.test.tsx
+++ b/src/pages/EntityDetails/EntityDetails.test.tsx
@@ -21,7 +21,7 @@ import {
   modelWatcherModelInfoFactory,
 } from "testing/factories/juju/model-watcher";
 
-import EntityDetails from "./EntityDetails";
+import EntityDetails, { Label } from "./EntityDetails";
 
 jest.mock("components/Topology/Topology", () => {
   const Topology = () => <div className="topology"></div>;
@@ -83,6 +83,7 @@ describe("Entity Details Container", () => {
             ownerTag: "user-kirk@external",
           }),
         },
+        modelsLoaded: true,
         modelWatcherData: {
           abc123: modelWatcherModelDataFactory.build({
             applications: {
@@ -103,13 +104,31 @@ describe("Entity Details Container", () => {
     expect(document.title).toEqual("Model: enterprise | Juju Dashboard");
   });
 
-  it("should show a spinner if waiting on data", () => {
-    state.juju.models = {};
+  it("should show a spinner if waiting on model list data", () => {
+    state.juju.modelsLoaded = false;
     state.juju.modelWatcherData = {};
     renderComponent({
       storeState: state,
     });
     expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+  });
+
+  it("should show a spinner if waiting on model data", () => {
+    state.juju.modelWatcherData = {};
+    renderComponent({
+      storeState: state,
+    });
+    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+  });
+
+  it("should show a not found message if the model does not exist", () => {
+    state.juju.models = {};
+    renderComponent({
+      storeState: state,
+    });
+    expect(
+      screen.getByRole("heading", { name: Label.NOT_FOUND })
+    ).toBeInTheDocument();
   });
 
   it("lists the correct tabs", () => {

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -1,9 +1,9 @@
-import { PropsWithChildren, useEffect, useState } from "react";
+import { useEffect, useState, PropsWithChildren, ReactNode } from "react";
 
 import { Spinner, Tabs } from "@canonical/react-components";
 import { useSelector, useStore } from "react-redux";
-import { useParams } from "react-router-dom";
-import { StringParam, useQueryParams, withDefault } from "use-query-params";
+import { useParams, Link } from "react-router-dom";
+import { useQueryParams, StringParam, withDefault } from "use-query-params";
 
 import BaseLayout from "layout/BaseLayout/BaseLayout";
 
@@ -11,6 +11,7 @@ import Breadcrumb from "components/Breadcrumb/Breadcrumb";
 import Header from "components/Header/Header";
 import SlidePanel from "components/SlidePanel/SlidePanel";
 import WebCLI from "components/WebCLI/WebCLI";
+import NotFound from "components/NotFound/NotFound";
 
 import ConfigPanel from "panels/ConfigPanel/ConfigPanel";
 import OffersPanel from "panels/OffersPanel/OffersPanel";
@@ -21,14 +22,19 @@ import {
   getControllerDataByUUID,
   getModelApplications,
   getModelInfo,
+  getModelListLoaded,
   getModelUUIDFromList,
 } from "store/juju/selectors";
-
+import { useAppSelector } from "store/store";
 import useWindowTitle from "hooks/useWindowTitle";
 
 import FadeIn from "animations/FadeIn";
 
 import "./_entity-details.scss";
+
+export enum Label {
+  NOT_FOUND = "Model not found",
+}
 
 type Props = {
   type?: string;
@@ -51,6 +57,7 @@ const EntityDetails = ({
   children,
 }: PropsWithChildren<Props>) => {
   const { userName, modelName } = useParams();
+  const modelsLoaded = useAppSelector(getModelListLoaded);
   const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
   const modelInfo = useSelector(getModelInfo(modelUUID));
   const applications = useSelector(getModelApplications(modelUUID));
@@ -173,6 +180,52 @@ const EntityDetails = ({
     return items;
   };
 
+  let content: ReactNode;
+  if (modelInfo) {
+    content = (
+      <FadeIn isActive={!!modelInfo}>
+        <div className="l-content">
+          <div className={`entity-details entity-details__${type}`}>
+            <>
+              {children}
+              {generateActivePanel()}
+            </>
+          </div>
+        </div>
+      </FadeIn>
+    );
+  } else if (modelsLoaded && !modelUUID) {
+    content = (
+      <div className="p-strip">
+        <div className="row">
+          <NotFound message={Label.NOT_FOUND}>
+            <>
+              <p>
+                Could not find a model named "{modelName}" for the user "
+                {userName}
+                ". If this is a model that belongs to another user then check
+                that you have been{" "}
+                <a href="https://juju.is/docs/olm/manage-users#heading--model-access">
+                  granted access
+                </a>
+                .
+              </p>
+              <p>
+                <Link to="/models">View all models</Link>
+              </p>
+            </>
+          </NotFound>
+        </div>
+      </div>
+    );
+  } else {
+    content = (
+      <div className="entity-details__loading" data-testid="loading-spinner">
+        <Spinner />
+      </div>
+    );
+  }
+
   return (
     <BaseLayout>
       <Header>
@@ -189,22 +242,7 @@ const EntityDetails = ({
           {additionalHeaderContent}
         </div>
       </Header>
-      {!modelInfo ? (
-        <div className="entity-details__loading" data-testid="loading-spinner">
-          <Spinner />
-        </div>
-      ) : (
-        <FadeIn isActive={!!modelInfo}>
-          <div className="l-content">
-            <div className={`entity-details entity-details__${type}`}>
-              <>
-                {children}
-                {generateActivePanel()}
-              </>
-            </div>
-          </div>
-        </FadeIn>
-      )}
+      {content}
       {showWebCLI && (
         <WebCLI
           controllerWSHost={controllerWSHost}

--- a/src/pages/ModelsIndex/ModelsIndex.test.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.test.tsx
@@ -15,7 +15,7 @@ import {
   modelDataStatusFactory,
 } from "testing/factories/juju/juju";
 
-import ModelsIndex from "./ModelsIndex";
+import ModelsIndex, { Label, TestId } from "./ModelsIndex";
 
 const mockStore = configureStore([]);
 
@@ -54,6 +54,7 @@ describe("Models Index page", () => {
             },
           }),
         },
+        modelsLoaded: true,
       }),
     });
   });
@@ -72,6 +73,38 @@ describe("Models Index page", () => {
     expect(document.querySelector(".header")).toBeInTheDocument();
     expect(screen.getAllByRole("grid")).toHaveLength(3);
     expect(document.querySelector(".chip-group")).toBeInTheDocument();
+  });
+
+  it("displays a spinner while loading models", () => {
+    state.juju.modelsLoaded = false;
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <QueryParamProvider adapter={ReactRouter6Adapter}>
+            <ModelsIndex />
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(screen.getByTestId(TestId.LOADING)).toBeInTheDocument();
+  });
+
+  it("displays a message if there are no models", () => {
+    state.juju.modelData = {};
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <QueryParamProvider adapter={ReactRouter6Adapter}>
+            <ModelsIndex />
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(
+      screen.getByRole("heading", { name: Label.NOT_FOUND })
+    ).toBeInTheDocument();
   });
 
   it("displays correct grouping view", async () => {

--- a/src/store/juju/reducers.test.ts
+++ b/src/store/juju/reducers.test.ts
@@ -62,7 +62,7 @@ describe("reducers", () => {
   });
 
   it("updateModelList", () => {
-    const state = jujuStateFactory.build();
+    const state = jujuStateFactory.build({ modelsLoaded: false });
     expect(
       reducer(
         state,
@@ -93,6 +93,7 @@ describe("reducers", () => {
           type: "model",
         }),
       },
+      modelsLoaded: true,
     });
   });
 
@@ -189,9 +190,10 @@ describe("reducers", () => {
       models: {
         abc123: modelListInfoFactory.build(),
       },
+      modelsLoaded: true,
     });
     expect(reducer(state, actions.clearModelData())).toStrictEqual(
-      jujuStateFactory.build()
+      jujuStateFactory.build({ modelsLoaded: false })
     );
   });
 

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -23,6 +23,7 @@ import {
   getAllModelApplicationStatus,
   getModelData,
   getControllerData,
+  getModelListLoaded,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -161,6 +162,18 @@ describe("selectors", () => {
         })
       )
     ).toStrictEqual(modelWatcherData.abc123.applications);
+  });
+
+  it("getModelListLoaded", () => {
+    expect(
+      getModelListLoaded(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            modelsLoaded: true,
+          }),
+        })
+      )
+    ).toBe(true);
   });
 
   it("getModelUnits", () => {

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -53,6 +53,15 @@ const getModelWatcherData = createSelector(
 
 const getModelList = createSelector([slice], (sliceState) => sliceState.models);
 
+/**
+  Get the loaded state of the model list.
+  @returns Whether the model list has been loaded.
+*/
+export const getModelListLoaded = createSelector(
+  [slice],
+  (sliceState) => sliceState.modelsLoaded
+);
+
 export function getModelWatcherDataByUUID(modelUUID: string) {
   return createSelector(getModelWatcherData, (modelWatcherData) => {
     if (modelWatcherData?.[modelUUID]) {

--- a/src/store/juju/slice.ts
+++ b/src/store/juju/slice.ts
@@ -11,6 +11,7 @@ const slice = createSlice({
   initialState: {
     controllers: null,
     models: {},
+    modelsLoaded: false,
     modelData: {},
     modelWatcherData: {},
     charms: [],
@@ -35,6 +36,7 @@ const slice = createSlice({
         };
       });
       state.models = modelList;
+      state.modelsLoaded = true;
     },
     updateModelStatus: (
       state,
@@ -87,6 +89,7 @@ const slice = createSlice({
     clearModelData: (state) => {
       state.modelData = {};
       state.models = {};
+      state.modelsLoaded = false;
     },
     clearControllerData: (state) => {
       state.controllers = {};

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -56,6 +56,7 @@ export type ModelsList = {
 export type JujuState = {
   controllers: Controllers | null;
   models: ModelsList;
+  modelsLoaded: boolean;
   modelData: ModelDataList;
   modelWatcherData?: ModelWatcherData;
   charms: Charm[];

--- a/src/store/middleware/model-poller.ts
+++ b/src/store/middleware/model-poller.ts
@@ -128,9 +128,8 @@ export const modelPollerMiddleware: Middleware<
               reduxStore.dispatch(
                 jujuActions.updateModelList({ models, wsControllerURL })
               );
-              const modelUUIDList = models["user-models"].map(
-                (item) => item.model.uuid
-              );
+              const modelUUIDList =
+                models["user-models"]?.map((item) => item.model.uuid) ?? [];
               await fetchAllModelStatuses(
                 wsControllerURL,
                 modelUUIDList,

--- a/src/testing/factories/juju/juju.ts
+++ b/src/testing/factories/juju/juju.ts
@@ -199,6 +199,7 @@ export const modelDataFactory = Factory.define<ModelData>(() => ({
 export const jujuStateFactory = Factory.define<JujuState>(() => ({
   controllers: null,
   models: {},
+  modelsLoaded: false,
   modelData: {},
   modelWatcherData: {},
   charms: [],


### PR DESCRIPTION
## Done

- Display a message when there are no models in the list.
- Display a message when loading a model that doesn't exist.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to the url for a model that doesn't exist e.g. /models/admin/notamodel and the spinner should disappear after loading the data you should see a message that it wasn't found.
- Go to the model list for a user that has no models. The spinner should disappear after the data loads and you should see a message about no models.

## Details

Fixes: #906.

## Screenshots

<img width="969" alt="Screenshot 2023-02-27 at 2 44 51 pm" src="https://user-images.githubusercontent.com/361637/221479942-025c5fa3-8cac-4656-b184-298ea7a8f82b.png">
<img width="992" alt="Screenshot 2023-02-27 at 2 47 21 pm" src="https://user-images.githubusercontent.com/361637/221479953-db2c76e5-680c-4a57-afdf-07b8e33448cb.png">
