### PR TITLE
WD-2351- Display controller endpoint configuration errors.

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -2,7 +2,8 @@
 // value to the golang template in config.js.go.
 // eslint-disable-next-line no-unused-vars
 var jujuDashboardConfig = {
-  // API host to allow app to connect and retrieve models
+  // API host to allow app to connect and retrieve models. This address should
+  // begin with `ws://` or `wss://` and end with `/api`.
   controllerAPIEndpoint: "wss://jimm.jujucharms.com/api",
   // Configurable base url to allow hosting the dashboard at different paths.
   baseAppURL: "/",

--- a/public/config.js.go
+++ b/public/config.js.go
@@ -1,5 +1,6 @@
 var jujuDashboardConfig = {
-  // API host to allow app to connect and retrieve models
+  // API host to allow app to connect and retrieve models. This address should
+  // begin with `ws://` or `wss://` and end with `/api`
   baseControllerURL: null,
   // Configurable base url to allow deploying to different paths.
   baseAppURL: "{{.baseAppURL}}",


### PR DESCRIPTION
## Done

- Validate and display controller endpoint configuration errors.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Change the value of controllerAPIEndpoint in your config.local.js to an invalid address (e.g. remove the /api or the wss://) and reload the dashboard.
- You should see an error message.

## Details

Fixes: #1237.
https://warthogs.atlassian.net/browse/WD-2351

## Screenshots

<img width="1511" alt="Screenshot 2023-02-28 at 11 25 32 am" src="https://user-images.githubusercontent.com/361637/221720346-587d99c9-f5a7-4b16-9f0a-58a603605bcf.png">

