### PR TITLE
WD-2350 - Fix "no models" appearing while loading

### DIFF
--- a/src/pages/ModelsIndex/ModelsIndex.test.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.test.tsx
@@ -13,6 +13,7 @@ import {
   modelDataFactory,
   modelDataApplicationFactory,
   modelDataStatusFactory,
+  modelListInfoFactory,
 } from "testing/factories/juju/juju";
 
 import ModelsIndex, { Label, TestId } from "./ModelsIndex";
@@ -25,6 +26,9 @@ describe("Models Index page", () => {
   beforeEach(() => {
     state = rootStateFactory.withGeneralConfig().build({
       juju: jujuStateFactory.build({
+        models: {
+          abc124: modelListInfoFactory.build(),
+        },
         modelData: {
           abc123: modelDataFactory.build({
             applications: {
@@ -91,7 +95,7 @@ describe("Models Index page", () => {
   });
 
   it("displays a message if there are no models", () => {
-    state.juju.modelData = {};
+    state.juju.models = {};
     const store = mockStore(state);
     render(
       <Provider store={store}>

--- a/src/pages/ModelsIndex/ModelsIndex.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.tsx
@@ -29,6 +29,7 @@ import {
   getGroupedModelStatusCounts,
   getModelData,
   getModelListLoaded,
+  hasModels,
 } from "store/juju/selectors";
 import { useAppSelector } from "store/store";
 
@@ -59,6 +60,7 @@ export default function Models() {
   });
 
   const modelsLoaded = useAppSelector(getModelListLoaded);
+  const hasSomeModels = useSelector(hasModels);
   // loop model data and pull out filter panel data
   const modelData = useSelector(getModelData);
   const { clouds, regions, owners, credentials } =
@@ -100,7 +102,7 @@ export default function Models() {
         <Spinner />
       </div>
     );
-  } else if (modelCount === 0) {
+  } else if (!hasSomeModels) {
     content = (
       <div className="l-content">
         <div className="models">

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -24,6 +24,7 @@ import {
   getModelData,
   getControllerData,
   getModelListLoaded,
+  hasModels,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -263,5 +264,19 @@ describe("selectors", () => {
         })
       )
     ).toStrictEqual({ "ceph-mon": "blocked" });
+  });
+
+  it("hasModels", () => {
+    expect(
+      hasModels(
+        rootStateFactory.build({
+          juju: jujuStateFactory.build({
+            models: {
+              abc123: modelListInfoFactory.build(),
+            },
+          }),
+        })
+      )
+    ).toBe(true);
   });
 });

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -62,6 +62,15 @@ export const getModelListLoaded = createSelector(
   (sliceState) => sliceState.modelsLoaded
 );
 
+/**
+  Whether there are any models in the model list.
+  @returns Whether the model list has been loaded.
+*/
+export const hasModels = createSelector(
+  [getModelList],
+  (modelList) => Object.keys(modelList).length > 0
+);
+
 export function getModelWatcherDataByUUID(modelUUID: string) {
   return createSelector(getModelWatcherData, (modelWatcherData) => {
     if (modelWatcherData?.[modelUUID]) {


### PR DESCRIPTION
## Done

- Correctly check for models so that the no models message doesn't appear while loading.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to the models list and refresh the page.
- While the models are loading you shouldn't see a "no models found" message.

## Details

Fixes: #1389.
https://warthogs.atlassian.net/browse/WD-2350

