### PR TITLE
WD-2349 - Default CLI help

### DIFF
--- a/src/components/WebCLI/Output.js
+++ b/src/components/WebCLI/Output.js
@@ -150,7 +150,7 @@ const WebCLIOutput = ({
   // Strip any color escape codes from the content.
   content = content.replace(/\\u001b/gi, "");
   const colorizedContent = useMemo(() => {
-    if (showHelp) {
+    if (showHelp || !content) {
       return helpMessage;
     }
     return colorize(content);

--- a/src/components/WebCLI/WebCLI.test.tsx
+++ b/src/components/WebCLI/WebCLI.test.tsx
@@ -94,6 +94,17 @@ describe("WebCLI", () => {
     });
   });
 
+  it("shows the help when there is no output", async () => {
+    await generateComponent();
+    return new Promise((resolve) => setTimeout(resolve)).then(() => {
+      expect(
+        document.querySelector(".webcli__output-content code")
+      ).toHaveTextContent(
+        `Welcome to the Juju Web CLI - see the full documentation here.`
+      );
+    });
+  });
+
   it("trims the command being submitted", async () => {
     const server = new WS("ws://localhost:1234/model/abc123/commands", {
       jsonProtocol: true,

--- a/src/components/WebCLI/__snapshots__/WebCLI.test.tsx.snap
+++ b/src/components/WebCLI/__snapshots__/WebCLI.test.tsx.snap
@@ -41,7 +41,17 @@ exports[`WebCLI renders correctly 1`] = `
         class="webcli__output-content"
         style="height: 1px;"
       >
-        <code />
+        <code>
+          Welcome to the Juju Web CLI - see the 
+          <a
+            class="p-link--inverted"
+            href="https://juju.is/docs/olm/using-the-juju-web-cli"
+            target="_blank"
+          >
+            full documentation here
+          </a>
+          .
+        </code>
       </pre>
     </div>
     <div

--- a/src/components/WebCLI/_webcli.scss
+++ b/src/components/WebCLI/_webcli.scss
@@ -39,7 +39,9 @@ $row-height: 2.5rem;
       flex-grow: 1;
     }
 
-    &-input[type="text"] {
+    &-input[type="text"],
+    &-input[type="text"]:focus,
+    &-input[type="text"]:hover {
       background-color: $color-x-dark;
       color: $color-mid-light;
       // https://github.com/canonical-web-and-design/vanilla-framework/pull/3370


### PR DESCRIPTION
## Done

- Show help when console is expanded.
- Fix console focus colour.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Click on a model (you'll need to be using a local Juju 2.9).
- Click on the command field at the bottom and type in some text. It should remain black and the text should be white (it got broken by the Vanilla update and the field would turn white).
- Drag open the terminal and you should see the welcome message.
- Enter in a command (e.g. `help`) and the welcome message should disappear.

## Details

Fixes: #1281.
https://warthogs.atlassian.net/browse/WD-2349

## Screenshots

<img width="884" alt="Screenshot 2023-02-28 at 4 46 55 pm" src="https://user-images.githubusercontent.com/361637/221765752-6eccba34-42db-4346-8006-cac4be89297c.png">

