### PR TITLE
Show Juju CLI on Juju 3

### DIFF
--- a/src/pages/EntityDetails/EntityDetails.test.tsx
+++ b/src/pages/EntityDetails/EntityDetails.test.tsx
@@ -212,6 +212,25 @@ describe("Entity Details Container", () => {
     });
   });
 
+  it("shows the CLI in juju higher than 2.9", async () => {
+    state.juju.modelWatcherData = {
+      abc123: modelWatcherModelDataFactory.build({
+        applications: {
+          "ceph-mon": applicationInfoFactory.build(),
+        },
+        model: modelWatcherModelInfoFactory.build({
+          name: "enterprise",
+          owner: "kirk@external",
+          version: "3.0.7",
+        }),
+      }),
+    };
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.queryByTestId("webcli")).toBeInTheDocument();
+    });
+  });
+
   it("does not show the webCLI in juju 2.8", async () => {
     state.juju.modelWatcherData = {
       abc123: modelWatcherModelDataFactory.build({

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -110,8 +110,10 @@ const EntityDetails = ({
   };
 
   useEffect(() => {
-    // XXX Remove me once we have the 2.9 build.
-    if (modelInfo && modelInfo?.version.indexOf("2.9") !== -1) {
+    // Regex to extract the first two numbers:
+    const versionRegex = /^\d+\.\d+/g;
+    const version = Number(versionRegex.exec(modelInfo?.version ?? "")?.[0]);
+    if (version >= 2.9) {
       // The Web CLI is only available in Juju controller versions 2.9 and
       // above. This will allow us to only show the shell on multi-controller
       // setups with different versions where the correct controller version


### PR DESCRIPTION
## Done

- Fix for the CLI not showing on Juju 3.

## QA

- Connect your dashboard to a Juju 3 instance.
- Load the dashboard and go to a model.
- The CLI input should appear at the bottom and you should be able to run commands.

## Details

Fixes: #1352.
https://warthogs.atlassian.net/browse/WD-2354

