### PR TITLE
WD-2356 - Support boolean action options

### DIFF
--- a/src/components/RadioInputBox/OptionInputs.test.tsx
+++ b/src/components/RadioInputBox/OptionInputs.test.tsx
@@ -34,6 +34,41 @@ describe("OptionInputs", () => {
     expect(container).toMatchSnapshot();
   });
 
+  it("can display a text input", () => {
+    const onValuesChange = jest.fn();
+    render(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <OptionInputs
+          name="MyAction"
+          options={options}
+          onValuesChange={onValuesChange}
+        />
+      </Formik>
+    );
+    expect(screen.getByRole("textbox", { name: "fruit" })).toBeInTheDocument();
+  });
+
+  it("can display a checkbox", () => {
+    const onValuesChange = jest.fn();
+    render(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <OptionInputs
+          name="MyAction"
+          options={[
+            {
+              name: "fruit",
+              description: "yum",
+              type: "boolean",
+              required: true,
+            },
+          ]}
+          onValuesChange={onValuesChange}
+        />
+      </Formik>
+    );
+    expect(screen.getByRole("checkbox", { name: "fruit" })).toBeInTheDocument();
+  });
+
   it("On input value change calls the onValuesChange handler", async () => {
     const onValuesChange = jest.fn();
     render(

--- a/src/components/RadioInputBox/OptionInputs.tsx
+++ b/src/components/RadioInputBox/OptionInputs.tsx
@@ -34,6 +34,14 @@ export default function OptionInputs({ name, options, onValuesChange }: Props) {
     <form>
       {options.map((option) => {
         const inputKey = `${name}-${option.name}`;
+        const field = (
+          <Field
+            className="radio-input-box__input"
+            type={option.type === "boolean" ? "checkbox" : "text"}
+            id={inputKey}
+            name={inputKey}
+          />
+        );
         return (
           <div
             className="radio-input-box__input-group"
@@ -45,14 +53,10 @@ export default function OptionInputs({ name, options, onValuesChange }: Props) {
               })}
               htmlFor={inputKey}
             >
+              {option.type === "boolean" ? field : null}
               {option.name}
             </label>
-            <Field
-              className="radio-input-box__input"
-              type="text"
-              id={inputKey}
-              name={inputKey}
-            />
+            {option.type === "boolean" ? null : field}
             <DescriptionSummary description={option.description} />
           </div>
         );

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -268,7 +268,8 @@ function onValuesChange(
 ) {
   const updatedValues: ActionOptionValue = {};
   Object.keys(values).forEach((key) => {
-    updatedValues[key.replace(`${actionName}-`, "")] = values[key];
+    // Use toString to convert booleans to strings as this is what the API requires.
+    updatedValues[key.replace(`${actionName}-`, "")] = values[key].toString();
   });
 
   optionValues.current = {
@@ -331,7 +332,11 @@ const requiredPopulated: RequiredPopulated = (
   if (required.length === 0) {
     return true;
   }
-  return !required.some((option) => optionsValues[selected][option] === "");
+  return !required.some((option) => {
+    const optionType = actionData[selected].params.properties[option].type;
+    const value = optionsValues[selected][option];
+    return optionType === "boolean" ? value !== "true" : value === "";
+  });
 };
 
 const optionsValidate: ValidationFnProps = (selected, optionsValues) => {

--- a/src/panels/ActionsPanel/CharmActionsPanel.tsx
+++ b/src/panels/ActionsPanel/CharmActionsPanel.tsx
@@ -225,7 +225,8 @@ function onValuesChange(
 ) {
   const updatedValues: ActionOptionValue = {};
   Object.keys(values).forEach((key) => {
-    updatedValues[key.replace(`${actionName}-`, "")] = values[key];
+    // Use toString to convert booleans to strings as this is what the API requires.
+    updatedValues[key.replace(`${actionName}-`, "")] = values[key].toString();
   });
 
   optionValues.current = {


### PR DESCRIPTION
## Done

- Support boolean action options.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Deploy and app that has boolean action options e.g. ceph-osd.
- Navigate to the unit list for that app and tick some units.
- Click 'Run action' and choose one of the actions that has a boolean option.
- Check that the boolean option has a checkbox instead of a text field.

## Details

#1204.
https://warthogs.atlassian.net/browse/WD-2356

## Screenshots

<img width="347" alt="Screenshot 2023-03-01 at 4 27 37 pm" src="https://user-images.githubusercontent.com/361637/222289190-4cb3da1d-d65c-4f8a-b0d2-bfde0e6d7323.png">

