### PR TITLE
WD-2409- Display copy button for ip addresses

### DIFF
--- a/src/scss/custom/_tables.scss
+++ b/src/scss/custom/_tables.scss
@@ -7,3 +7,19 @@ th,
 td {
   min-width: 150px;
 }
+
+td.has-hover {
+  .has-hover__hover-state {
+    display: none;
+  }
+
+  &:hover .has-hover__hover-state {
+    display: block;
+  }
+}
+
+td {
+  [class^="p-button"].is-small {
+    margin: -$input-border-thickness 0 0;
+  }
+}

--- a/src/tables/tableRows.tsx
+++ b/src/tables/tableRows.tsx
@@ -11,8 +11,9 @@ import {
   generateRelationIconImage,
   generateStatusElement,
   generateIconImg,
+  copyToClipboard,
 } from "components/utils";
-import { Tooltip } from "@canonical/react-components";
+import { Button, Icon, Tooltip } from "@canonical/react-components";
 import {
   MainTableCell,
   MainTableRow,
@@ -34,19 +35,23 @@ export type Query = {
   activeView?: string | null;
 };
 
-const generateLink = (address?: string | null) =>
+const generateAddress = (address?: string | null) =>
   address ? (
-    <a
-      href={`http://${address}`}
-      onClick={(event) => {
-        // Prevent navigating to the details page:
-        event.stopPropagation();
-      }}
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      {address}
-    </a>
+    <>
+      {address}{" "}
+      <Button
+        appearance="base"
+        className="has-hover__hover-state is-small"
+        onClick={(event) => {
+          // Prevent navigating to the details page:
+          event.stopPropagation();
+          copyToClipboard(address);
+        }}
+        hasIcon
+      >
+        <Icon name="copy" />
+      </Button>
+    </>
   ) : (
     "-"
   );
@@ -262,7 +267,8 @@ export function generateUnitRows(
         key: "machine",
       },
       {
-        content: generateLink(publicAddress),
+        content: generateAddress(publicAddress),
+        className: "u-flex has-hover",
       },
       {
         content: ports,
@@ -321,7 +327,7 @@ export function generateUnitRows(
       for (let [key] of Object.entries(subordinates)) {
         const subordinate = subordinates[key];
         const address = subordinate["public-address"];
-        let columns = [
+        let columns: MainTableCell[] = [
           {
             content: generateEntityIdentifier(
               subordinate["charm-url"],
@@ -338,7 +344,7 @@ export function generateUnitRows(
           },
           { content: subordinate["agent-status"].current },
           { content: subordinate["machine-id"], className: "u-align--right" },
-          { content: generateLink(address) },
+          { content: generateAddress(address), className: "u-flex has-hover" },
           {
             content: subordinate["public-address"].split(":")[-1] || "-",
             className: "u-align--right",

--- a/src/tables/tableRows.tsx
+++ b/src/tables/tableRows.tsx
@@ -34,6 +34,23 @@ export type Query = {
   activeView?: string | null;
 };
 
+const generateLink = (address?: string | null) =>
+  address ? (
+    <a
+      href={`http://${address}`}
+      onClick={(event) => {
+        // Prevent navigating to the details page:
+        event.stopPropagation();
+      }}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      {address}
+    </a>
+  ) : (
+    "-"
+  );
+
 export function generateLocalApplicationRows(
   applications: ApplicationData | null,
   applicationStatuses: StatusData | null,
@@ -225,7 +242,7 @@ export function generateUnitRows(
     const unit = clonedUnits[unitId];
     const workload = unit["workload-status"].current || "-";
     const agent = unit["agent-status"].current || "-";
-    const publicAddress = unit["public-address"] || "-";
+    const publicAddress = unit["public-address"];
     const ports = generatePortsList(unit.ports);
     const message = unit["workload-status"].message || "-";
     const charm = unit["charm-url"];
@@ -244,7 +261,9 @@ export function generateUnitRows(
         className: "u-align--right",
         key: "machine",
       },
-      { content: publicAddress },
+      {
+        content: generateLink(publicAddress),
+      },
       {
         content: ports,
         className: "u-align--right",
@@ -301,6 +320,7 @@ export function generateUnitRows(
     if (subordinates) {
       for (let [key] of Object.entries(subordinates)) {
         const subordinate = subordinates[key];
+        const address = subordinate["public-address"];
         let columns = [
           {
             content: generateEntityIdentifier(
@@ -318,7 +338,7 @@ export function generateUnitRows(
           },
           { content: subordinate["agent-status"].current },
           { content: subordinate["machine-id"], className: "u-align--right" },
-          { content: subordinate["public-address"] },
+          { content: generateLink(address) },
           {
             content: subordinate["public-address"].split(":")[-1] || "-",
             className: "u-align--right",


### PR DESCRIPTION
## Done

- Update the unit list with a hover button to copy the address.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Navigate to an application that has units with exposed IPs.
- Hover an IP address and you should see a copy button. Click the button and the address should get copied.

## Details

Fixes: #725.
https://warthogs.atlassian.net/browse/WD-2409

## Screenshots
![Screen Recording 2023-03-09 at 9 52 04 am](https://user-images.githubusercontent.com/361637/223869863-6c8c62ac-64e7-4545-a0e7-867ffef2ab65.gif)



