### PR TITLE
WD-2410 - Compensate for WebCLI

### DIFF
--- a/src/components/WebCLI/_webcli.scss
+++ b/src/components/WebCLI/_webcli.scss
@@ -1,9 +1,9 @@
 @import "../../scss/settings";
 @import "../../scss/breakpoints";
+@import "../../scss/variables";
 @import "vanilla-framework/scss/vanilla";
 
 $canonical-purple: #2c001e;
-$row-height: 2.5rem;
 
 .webcli {
   bottom: 0;
@@ -20,7 +20,7 @@ $row-height: 2.5rem;
   &__input {
     background-color: $color-x-dark;
     display: flex;
-    height: $row-height;
+    height: $webcli-input-height;
     padding: 0 1rem;
 
     &-prompt {
@@ -31,7 +31,7 @@ $row-height: 2.5rem;
       // XXX The unquote will need to be removed with the next vanilla release
       font-family: unquote($font-monospace);
       font-weight: bold;
-      line-height: $row-height;
+      line-height: $webcli-input-height;
       padding-right: 0.5rem;
     }
 
@@ -45,14 +45,14 @@ $row-height: 2.5rem;
       // https://github.com/canonical-web-and-design/vanilla-framework/pull/3370
       // XXX The unquote will need to be removed with the next vanilla release
       font-family: unquote($font-monospace);
-      height: $row-height;
+      height: $webcli-input-height;
       margin-bottom: 0;
       padding: 0 0.5rem;
     }
 
     &-help {
       flex-grow: 0;
-      line-height: $row-height;
+      line-height: $webcli-input-height;
       margin-left: 1rem;
 
       i {
@@ -64,7 +64,7 @@ $row-height: 2.5rem;
   &__output {
     background-color: $canonical-purple;
     height: 300px;
-    min-height: 10px;
+    min-height: $webcli-drag-height;
     overflow: hidden;
 
     a {
@@ -89,7 +89,7 @@ $row-height: 2.5rem;
 
     &-dragarea {
       cursor: row-resize;
-      height: 10px;
+      height: $webcli-drag-height;
       user-select: none;
       width: 100%;
     }

--- a/src/layout/BaseLayout/_base-layout.scss
+++ b/src/layout/BaseLayout/_base-layout.scss
@@ -2,6 +2,7 @@
 @import "vanilla-framework/scss/vanilla";
 @import "../../scss/functions/z-index";
 @import "../../scss/breakpoints";
+@import "../../scss/variables";
 
 @mixin collapsed {
   // Disable stylelint rules that are conflicting with prettier.
@@ -122,6 +123,10 @@
 
 .l-content {
   margin: 0.5rem 1rem;
+}
+
+.l-content--has-webcli {
+  margin-bottom: calc(1rem + #{$webcli-height});
 }
 
 .l-application {

--- a/src/pages/EntityDetails/EntityDetails.test.tsx
+++ b/src/pages/EntityDetails/EntityDetails.test.tsx
@@ -232,4 +232,13 @@ describe("Entity Details Container", () => {
       expect(screen.queryByTestId("webcli")).not.toBeInTheDocument();
     });
   });
+
+  it("gives the content a class when the webCLI is shown", async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(document.querySelector(".l-content")).toHaveClass(
+        "l-content--has-webcli"
+      );
+    });
+  });
 });

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, PropsWithChildren, ReactNode } from "react";
-
+import classNames from "classnames";
 import { Spinner, Tabs } from "@canonical/react-components";
 import { useSelector, useStore } from "react-redux";
 import { useParams, Link } from "react-router-dom";
@@ -184,7 +184,11 @@ const EntityDetails = ({
   if (modelInfo) {
     content = (
       <FadeIn isActive={!!modelInfo}>
-        <div className="l-content">
+        <div
+          className={classNames("l-content", {
+            "l-content--has-webcli": showWebCLI,
+          })}
+        >
           <div className={`entity-details entity-details__${type}`}>
             <>
               {children}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,0 +1,3 @@
+$webcli-input-height: 2.5rem;
+$webcli-drag-height: 10px;
+$webcli-height: calc(#{$webcli-input-height} + #{$webcli-drag-height});


### PR DESCRIPTION
## Done

- Compensate for WebCLI at bottom of content.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to a model that has a lot of apps (e.g. openstack).
- Check that you can scroll to the bottom of the content and nothing is cut off by the CLI.

## Details

Fixes: 1395.
https://warthogs.atlassian.net/browse/WD-2410

## Screenshots

Bottom space without CLI:
<img width="1086" alt="Screenshot 2023-03-03 at 3 58 38 pm" src="https://user-images.githubusercontent.com/361637/222643088-12fe1f84-f842-4af7-ad29-ede9de898953.png">
Bottom space with CLI:
<img width="1088" alt="Screenshot 2023-03-03 at 3 58 52 pm" src="https://user-images.githubusercontent.com/361637/222643096-04fb5cd2-7025-4ab1-bf39-892282864238.png">

