### PR TITLE
WD-2424 - Display unknown action log dates

### DIFF
--- a/src/pages/EntityDetails/Model/ActionLogs/ActionLogs.tsx
+++ b/src/pages/EntityDetails/Model/ActionLogs/ActionLogs.tsx
@@ -251,6 +251,7 @@ export default function ActionLogs() {
               ...newData,
             });
           }
+          const completedDate = new Date(actionData.completed);
           newData = {
             application: (
               <>
@@ -285,14 +286,18 @@ export default function ActionLogs() {
                 )}
               </>
             ),
-            completed: (
-              <Tooltip
-                message={new Date(actionData.completed).toLocaleString()}
-                position="top-center"
-              >
-                {formatFriendlyDateToNow(actionData.completed)}
-              </Tooltip>
-            ),
+            completed:
+              // Sometimes the log gets returned with a date of "0001-01-01T00:00:00Z".
+              completedDate.getFullYear() === 1 ? (
+                "Unknown"
+              ) : (
+                <Tooltip
+                  message={completedDate.toLocaleString()}
+                  position="top-center"
+                >
+                  {formatFriendlyDateToNow(actionData.completed)}
+                </Tooltip>
+              ),
             controls: (
               <>
                 <ContextualMenu


### PR DESCRIPTION
## Done

Display action log dates of 0001-01-01T00:00:00Z as Unknown.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Run some actions that return dates as 0001-01-01T00:00:00Z (I don't actually know which ones do this but it seems to happen frequently).
- Go to the action log and you should see the date as "Unknown".

## Details

#1351
https://warthogs.atlassian.net/browse/WD-2424

## Screenshots

Before:
<img width="399" alt="Screenshot 2023-03-06 at 10 39 00 am" src="https://user-images.githubusercontent.com/361637/222994341-68f3788d-826f-4d12-9a81-fda5e9ec7b77.png">


After:
<img width="412" alt="Screenshot 2023-03-06 at 10 43 44 am" src="https://user-images.githubusercontent.com/361637/222994354-1bb3b2d8-5918-4cfd-be79-391c44fff658.png">


