### PR TITLE
WD-2425 - Display the controller region and cloud

### DIFF
--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -328,7 +328,7 @@ export async function fetchAllModelStatuses(
       if (isLoggedIn(getState(), wsControllerURL)) {
         const modelInfo = await fetchModelInfo(conn, modelUUID);
         dispatch(jujuActions.updateModelInfo({ modelInfo, wsControllerURL }));
-        if (modelInfo.results[0].result.isController) {
+        if (modelInfo.results[0].result["is-controller"]) {
           // If this is a controller model then update the
           // controller data with this model data.
           dispatch(addControllerCloudRegion({ wsControllerURL, modelInfo }));

--- a/src/store/juju/thunks.ts
+++ b/src/store/juju/thunks.ts
@@ -4,6 +4,7 @@ import { ModelInfoResults } from "@canonical/jujulib/dist/api/facades/model-mana
 import { actions as jujuActions } from "store/juju";
 import { RootState } from "store/store";
 import { checkLoggedIn } from "store/middleware/check-auth";
+import cloneDeep from "clone-deep";
 
 /**
   Updates the correct controller entry with a cloud and region fetched from
@@ -21,8 +22,12 @@ export const addControllerCloudRegion = createAsyncThunk<
 >(
   "juju/addControllerCloudRegion",
   async ({ wsControllerURL, modelInfo }, thunkAPI) => {
-    const controllers =
-      thunkAPI.getState()?.juju?.controllers?.[wsControllerURL];
+    // Get a copy of the store data so it can be manipulated before dispatching
+    // the update. Without this the modifications were silently failing,
+    // possibly because the data was being made immutable by Immer.
+    const controllers = cloneDeep(
+      thunkAPI.getState()?.juju?.controllers?.[wsControllerURL]
+    );
     const model = modelInfo.results[0].result;
     if (controllers) {
       const updatedControllers = controllers.map((controller) => {

--- a/src/store/middleware/check-auth.ts
+++ b/src/store/middleware/check-auth.ts
@@ -5,6 +5,7 @@
 
 import { Middleware } from "redux";
 import { actions as appActions, thunks as appThunks } from "store/app";
+import { addControllerCloudRegion } from "store/juju/thunks";
 import { actions as generalActions } from "store/general";
 import { isLoggedIn } from "store/general/selectors";
 import { actions as jujuActions } from "store/juju";
@@ -77,6 +78,9 @@ export const checkAuthMiddleware: Middleware<
       appThunks.logOut.fulfilled.type,
       appThunks.logOut.pending.type,
       appThunks.logOut.rejected.type,
+      addControllerCloudRegion.fulfilled.type,
+      addControllerCloudRegion.pending.type,
+      addControllerCloudRegion.rejected.type,
     ];
 
     const state = getState();


### PR DESCRIPTION
## Done

- Fix the controller list to display the controller region and cloud instead of "unknown."

## QA

- Run the dashboard against a local controller (i.e. not JAAS).
- Go to the controller list and check that the cloud and region are displayed.

## Details

Fixes: #1087.
https://warthogs.atlassian.net/browse/WD-2425

## Screenshots

<img width="522" alt="Screenshot 2023-03-06 at 2 38 57 pm" src="https://user-images.githubusercontent.com/361637/223015998-3e4c8151-8a9c-45c2-80bf-a4396656858b.png">

