### PR TITLE
WD-2427 - Unit local app title

### DIFF
--- a/src/pages/EntityDetails/Machine/Machine.tsx
+++ b/src/pages/EntityDetails/Machine/Machine.tsx
@@ -19,7 +19,7 @@ import {
 } from "tables/tableRows";
 
 import {
-  localApplicationTableHeaders,
+  generateLocalApplicationTableHeaders,
   unitTableHeaders,
 } from "tables/tableHeaders";
 
@@ -115,7 +115,7 @@ export default function Machine() {
               emptyStateMsg={"There are no units in this machine"}
             />
             <MainTable
-              headers={localApplicationTableHeaders}
+              headers={generateLocalApplicationTableHeaders()}
               rows={applicationRows}
               className="entity-details__apps p-main-table"
               sortable

--- a/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.tsx
@@ -12,7 +12,7 @@ import {
 
 import {
   appsOffersTableHeaders,
-  localApplicationTableHeaders,
+  generateLocalApplicationTableHeaders,
   remoteApplicationTableHeaders,
 } from "tables/tableHeaders";
 import {
@@ -229,7 +229,7 @@ export default function ApplicationsTab({ filterQuery }: Props) {
   );
 
   const LocalAppsTable = () => {
-    let headers = localApplicationTableHeaders;
+    let headers = generateLocalApplicationTableHeaders();
     let rows = localApplicationTableRows;
     if (filterQuery) {
       headers = addSelectAllColumn(headers, selectAll, handleSelectAll);

--- a/src/pages/EntityDetails/Unit/Unit.tsx
+++ b/src/pages/EntityDetails/Unit/Unit.tsx
@@ -6,7 +6,7 @@ import { useParams } from "react-router-dom";
 import useTableRowClick from "hooks/useTableRowClick";
 
 import {
-  localApplicationTableHeaders,
+  generateLocalApplicationTableHeaders,
   machineTableHeaders,
 } from "tables/tableHeaders";
 
@@ -114,7 +114,7 @@ export default function Unit() {
             />
           )}
           <MainTable
-            headers={localApplicationTableHeaders}
+            headers={generateLocalApplicationTableHeaders(false)}
             rows={applicationRows}
             className="entity-details__apps p-main-table"
             sortable

--- a/src/tables/tableHeaders.tsx
+++ b/src/tables/tableHeaders.tsx
@@ -9,8 +9,10 @@ type HeaderRow = {
   className?: string;
 };
 
-export const localApplicationTableHeaders: Header = [
-  { content: "local apps", sortKey: "local-apps" },
+export const generateLocalApplicationTableHeaders = (
+  multipleApps = true
+): Header => [
+  { content: `local app${multipleApps ? "s" : ""}`, sortKey: "local-apps" },
   { content: "status", sortKey: "status" },
   { content: "version", sortKey: "version" },
   { content: "scale", className: "u-align--right", sortKey: "scale" },


### PR DESCRIPTION
## Done

Use the correct plural for the local app on a unit.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Visit the applications list for a model and check that the title of the first column in the apps table is "Local apps".
- Click on an app and then click on a unit and check that the title of the first column in the apps table is "Local app".
- Click on a machine and check that the title of the first column in the apps table is "Local apps".

## Details

Fixes: #937.
https://warthogs.atlassian.net/browse/


## Screenshots

Apps:

<img width="698" alt="Screenshot 2023-03-06 at 4 12 14 pm" src="https://user-images.githubusercontent.com/361637/223032310-7a48992e-df54-498d-be66-b96354895f6f.png">

Unit:

<img width="705" alt="Screenshot 2023-03-06 at 4 13 02 pm" src="https://user-images.githubusercontent.com/361637/223032314-41543bfe-ac95-4166-857a-ddf3e62cd6f4.png">

Machine:

<img width="718" alt="Screenshot 2023-03-06 at 4 11 56 pm" src="https://user-images.githubusercontent.com/361637/223032299-b666c3f3-eefd-4fc2-94d8-0256e5ba558b.png">