### PR TITLE
WD-2456 - Remove custom th spacing for controllers

### DIFF
--- a/src/pages/ControllersIndex/_controllers.scss
+++ b/src/pages/ControllersIndex/_controllers.scss
@@ -1,11 +1,6 @@
 @import "vanilla-framework/scss/vanilla";
 
 .controllers {
-  th {
-    padding-bottom: 6px;
-    padding-top: 6px;
-  }
-
   td,
   th {
     &:first-child {


### PR DESCRIPTION
## Done

Remove custom th spacing for controllers so that the header spacing is the same as models.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to the controller list and check that the spacing between the table header and border is the same as the model list.

## Details

Fixes: #695.
https://warthogs.atlassian.net/browse/WD-2456

## Screenshots

<img width="345" alt="Screenshot 2023-03-07 at 9 32 13 am" src="https://user-images.githubusercontent.com/361637/223264689-c1bd3a4f-1e57-4626-8e7b-254fb8e0b72f.png">

