### PR TITLE
WD-2457 - Add help about admins executing actions

### DIFF
--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -359,8 +359,8 @@ export default function ShareModel() {
                     admin
                     <span className="help-text">
                       In addition to 'write' abilities, a user can perform model
-                      upgrades and connect to machines via juju ssh. Makes the
-                      user an effective model owner.
+                      upgrades, execute actions and connect to machines via juju
+                      ssh. Makes the user an effective model owner.
                     </span>
                   </>
                 }


### PR DESCRIPTION
## Done

- Add help about admins executing actions.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Open the access panel for a model.
- Under the admin option it should mention that admins can execute actions.

## Details

https://warthogs.atlassian.net/browse/WD-2457
Fixes: #1037.

## Screenshots

<img width="262" alt="Screenshot 2023-03-07 at 9 49 09 am" src="https://user-images.githubusercontent.com/361637/223273380-ebdd7293-48ca-4649-99ca-e93484541167.png">

