### PR TITLE
WD-2458 - Fix config panel scrolling

### DIFF
--- a/src/components/Header/_header.scss
+++ b/src/components/Header/_header.scss
@@ -2,12 +2,13 @@
 @import "vanilla-framework/scss/vanilla";
 @import "../../scss/functions/z-index";
 @import "../../scss/breakpoints";
+@import "../../scss/variables";
 
 .header {
   background-color: $color-x-light;
   border-bottom: 1px solid $color-mid-light;
   display: block;
-  min-height: 4rem;
+  min-height: $top-header-height;
   padding: 0 1rem;
   z-index: z("gamma");
 

--- a/src/components/SlidePanel/_slide-panel.scss
+++ b/src/components/SlidePanel/_slide-panel.scss
@@ -1,11 +1,10 @@
 @import "vanilla-framework/scss/vanilla";
 @import "../../scss/functions/z-index";
 @import "../../scss/breakpoints";
+@import "../../scss/variables";
 
 .slide-panel {
   @include vf-animation(transform, brisk, out);
-
-  $top-header-height: 64px;
 
   background-color: $color-x-light;
   height: calc(100% - #{$top-header-height});

--- a/src/panels/ConfigPanel/ConfigPanel.tsx
+++ b/src/panels/ConfigPanel/ConfigPanel.tsx
@@ -243,7 +243,7 @@ export default function ConfigPanel({
       isLoading={!appName}
       className="config-panel"
     >
-      <div className="config-panel">
+      <div>
         {isLoading ? (
           <div className="full-size u-vertically-center">
             <Spinner />
@@ -359,7 +359,8 @@ async function getConfig(
     (result) => {
       // Add the key to the config object to make for easier use later.
       const config: Config = {};
-      Object.keys(result.config).forEach((key) => {
+      // The config param can be null.
+      Object.keys(result.config ?? {}).forEach((key) => {
         config[key] = result.config[key];
         config[key].name = key;
       });

--- a/src/panels/ConfigPanel/_config-panel.scss
+++ b/src/panels/ConfigPanel/_config-panel.scss
@@ -1,14 +1,23 @@
 @import "vanilla-framework/scss/vanilla";
 @import "../../scss/settings";
 @import "../../scss/breakpoints";
+@import "../../scss/variables";
+
+$panel-padding: 1.5rem;
 
 .slide-panel.config-panel .slide-panel__content {
-  padding: 1.5rem 0 0;
+  padding: $panel-padding 0 0;
 }
 
 .config-panel {
-  $magic-height: 200px;
-  $magic-min-height: calc(100vh - #{$magic-height});
+  $magic-title-height: 4.7rem;
+  $magic-drawer-height: 5rem;
+
+  /* prettier-ignore */
+  $magic-non-content-height: ($panel-padding * 2) + $top-header-height + $magic-drawer-height + $magic-title-height;
+  $magic-min-height: calc(100vh - #{$magic-non-content-height});
+
+  overflow-y: auto;
 
   &__modal-button-row-hint {
     font-size: 0.875rem;

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,3 +1,4 @@
+$top-header-height: 4rem;
 $webcli-input-height: 2.5rem;
 $webcli-drag-height: 10px;
 $webcli-height: calc(#{$webcli-input-height} + #{$webcli-drag-height});


### PR DESCRIPTION
## Done

- Fix the config panel so that it scrolls if there are too many config options to appear on the screen.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to an app that has a lot of config options and click the 'Configure' button to show the panel.
- Check that you can scroll down to see all the options.
- Check that the panel for an app with a small number of options does not scroll.

## Details

Fixes: #1407.
https://warthogs.atlassian.net/browse/WD-2458

## Screenshots

![Screen Recording 2023-03-07 at 11 12 57 am](https://user-images.githubusercontent.com/361637/223309182-4008e0c0-70b3-4bec-9ef0-a99697cf4c28.gif)

