### PR TITLE
Show action payload in details

### DIFF
--- a/src/components/utils.tsx
+++ b/src/components/utils.tsx
@@ -120,3 +120,12 @@ export const formatFriendlyDateToNow = (date: string) => {
   const formattedDate = formatDistanceToNow(parseISO(date));
   return formattedDate.concat(" ago");
 };
+
+export const copyToClipboard = (text: string) => {
+  const input = document.createElement("input");
+  input.setAttribute("value", text);
+  document.body.appendChild(input);
+  input.select();
+  document.execCommand("copy");
+  document.body.removeChild(input);
+};

--- a/src/pages/EntityDetails/Model/ActionLogs/ActionLogs.test.tsx
+++ b/src/pages/EntityDetails/Model/ActionLogs/ActionLogs.test.tsx
@@ -1,8 +1,8 @@
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import configureStore from "redux-mock-store";
 
 import {
   actionFactory,
@@ -16,13 +16,13 @@ import {
 import ActionLogs, {
   Label,
 } from "pages/EntityDetails/Model/ActionLogs/ActionLogs";
+import { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
 import {
   jujuStateFactory,
   modelDataFactory,
   modelDataInfoFactory,
 } from "testing/factories/juju/juju";
-import { RootState } from "store/store";
 
 import { Output } from "./ActionLogs";
 
@@ -68,6 +68,10 @@ const mockActionResults = actionResultsFactory.build({
           message: "log message 1",
         }),
       ],
+      output: {
+        key1: "value1",
+        test: 123,
+      },
     }),
     actionResultFactory.build({
       action: actionFactory.build({
@@ -84,6 +88,7 @@ const mockActionResults = actionResultsFactory.build({
           message: "log message 2",
         }),
       ],
+      output: { "return-code": "1" },
       status: "failed",
       message: "error message",
     }),
@@ -156,6 +161,7 @@ describe("Action Logs", () => {
         "log message 1",
         "over 1 year ago",
         "Output",
+        "Result",
       ],
       [
         "└easyrsa/1",
@@ -186,6 +192,7 @@ describe("Action Logs", () => {
         "log message 1",
         "over 1 year ago",
         "Output",
+        "Result",
       ],
       [
         "└easyrsa/1",
@@ -217,5 +224,29 @@ describe("Action Logs", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: Output.STDERR }));
     expect(within(rows[3]).getByText("error message")).toBeInTheDocument();
+  });
+
+  it("only shows the action result button when there is a result", async () => {
+    generateComponent();
+    const showOutputBtns = await screen.findAllByTestId("show-output");
+    expect(showOutputBtns.length).toBe(1);
+  });
+
+  it("shows the payload when the action result button is clicked", async () => {
+    generateComponent();
+    const showOutputBtn = await screen.findByTestId("show-output");
+    await userEvent.click(showOutputBtn);
+    const modal = await screen.findByTestId("action-payload-modal");
+    expect(modal).toBeInTheDocument();
+  });
+
+  it("closes the payload modal when the close button is clicked", async () => {
+    generateComponent();
+    const showOutputBtn = await screen.findByTestId("show-output");
+    await userEvent.click(showOutputBtn);
+    const modal = await screen.findByTestId("action-payload-modal");
+    expect(modal).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("Close active modal"));
+    expect(modal).not.toBeInTheDocument();
   });
 });

--- a/src/pages/EntityDetails/Model/ActionLogs/ActionLogs.tsx
+++ b/src/pages/EntityDetails/Model/ActionLogs/ActionLogs.tsx
@@ -303,6 +303,7 @@ export default function ActionLogs() {
             <div className="entity-details__action-buttons">
               <ContextualMenu
                 hasToggleIcon
+                toggleProps={{ dense: true }}
                 toggleLabel={
                   outputType === Output.ALL ? Label.OUTPUT : outputType
                 }
@@ -330,6 +331,7 @@ export default function ActionLogs() {
                 <Button
                   onClick={() => setModalDetails(actionFullDetails.output)}
                   data-testid="show-output"
+                  dense
                 >
                   Result
                 </Button>

--- a/src/pages/EntityDetails/Model/ActionLogs/_action-logs.scss
+++ b/src/pages/EntityDetails/Model/ActionLogs/_action-logs.scss
@@ -2,6 +2,17 @@
 @import "vanilla-framework/scss/vanilla";
 
 @mixin action-logs {
+  .entity-details__action-logs {
+    table {
+      // log messages column
+      th:nth-child(5),
+      // control buttons column
+      th:nth-child(7) {
+        width: 20%;
+      }
+    }
+  }
+
   .action-logs__stdout {
     display: block;
   }

--- a/src/pages/EntityDetails/Model/ActionLogs/_action-logs.scss
+++ b/src/pages/EntityDetails/Model/ActionLogs/_action-logs.scss
@@ -9,6 +9,12 @@
   .action-logs__stderr {
     color: $color-negative;
   }
+
+  .entity-details__action-buttons {
+    & > * {
+      margin-right: $sp-small !important;
+    }
+  }
 }
 
 @include action-logs;


### PR DESCRIPTION
## Done

- Only show the "show action payload" when the action returns a payload
- Show the payload in a modal with "copy to clipboard' button

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Run an action that returns a payload (charm in the screenshots [qa-test](https://github1s.com/goulinkh/qa-juju-charm)), inside the payload handler this line is called:
```py
event.set_results({"key": "value"})
```
- Make sure that there is another button shown in the actions logs
- Click on that button
- Make sure that the action payload is shown in a modal

## Issues

https://github.com/canonical/jaas-dashboard/issues/1277
https://warthogs.atlassian.net/browse/WD-2423

## Screenshots

![image](https://user-images.githubusercontent.com/36013798/223369957-24831b16-1fd2-4ed4-aafd-d538d0da030d.png)

### Payload popup
![image](https://user-images.githubusercontent.com/36013798/223370122-9c4896f8-d76c-425e-9210-6c3750b6a021.png)
