### PR TITLE
WD-2459 - config errors and validation

### DIFF
--- a/src/juju/api.ts
+++ b/src/juju/api.ts
@@ -26,6 +26,7 @@ import Cloud from "@canonical/jujulib/dist/api/facades/cloud";
 import Controller from "@canonical/jujulib/dist/api/facades/controller";
 import ModelManager from "@canonical/jujulib/dist/api/facades/model-manager";
 import Pinger from "@canonical/jujulib/dist/api/facades/pinger";
+import { ErrorResults } from "@canonical/jujulib/dist/api/facades/application/ApplicationV15";
 
 import { Charm } from "@canonical/jujulib/dist/api/facades/charms/CharmsV2";
 import { AllWatcherId } from "@canonical/jujulib/dist/api/facades/client/ClientV6";
@@ -478,7 +479,7 @@ export async function setApplicationConfig(
   appName: string,
   config: Config,
   appState: RootState
-) {
+): Promise<ErrorResults> {
   const conn = await connectAndLoginToModel(modelUUID, appState);
   const setValues: Record<string, string> = {};
   Object.keys(config).forEach((key) => {

--- a/src/panels/ConfigPanel/BooleanConfig.tsx
+++ b/src/panels/ConfigPanel/BooleanConfig.tsx
@@ -1,10 +1,5 @@
-import classnames from "classnames";
-import { useEffect, useRef, useState } from "react";
-
-import { isSet } from "components/utils";
-
 import { RadioInput } from "@canonical/react-components";
-import type { ConfigProps } from "./ConfigPanel";
+import ConfigField, { ConfigProps } from "./ConfigField";
 
 export default function BooleanConfig({
   config,
@@ -12,143 +7,43 @@ export default function BooleanConfig({
   setSelectedConfig,
   setNewValue,
 }: ConfigProps): JSX.Element {
-  const [inputFocused, setInputFocused] = useState(false);
-  const [inputChanged, setInputChanged] = useState(false);
-  const [showDescription, setShowDescription] = useState(false);
-  const [showUseDefault, setShowUseDefault] = useState(
-    config.value !== config.default
-  );
-  const descriptionRef = useRef<HTMLDivElement>(null);
-  const [maxDescriptionHeight, setMaxDescriptionHeight] = useState("0px");
-
-  let inputValue = config.default;
-  if (isSet(config.newValue)) {
-    inputValue = config.newValue;
-  } else if (config.default !== config.value) {
-    inputValue = config.value;
-  }
-
-  useEffect(() => {
-    if (descriptionRef.current?.firstChild) {
-      setMaxDescriptionHeight(
-        `${
-          (descriptionRef.current.firstChild as HTMLPreElement).clientHeight
-        }px`
-      );
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!descriptionRef.current) {
-      return;
-    }
-    if (showDescription) {
-      descriptionRef.current.style.maxHeight = maxDescriptionHeight;
-    } else {
-      descriptionRef.current.style.maxHeight = "0px";
-    }
-  }, [showDescription, maxDescriptionHeight]);
-
-  useEffect(() => {
-    if (selectedConfig?.name === config.name) {
-      setInputFocused(true);
-    } else {
-      setInputFocused(false);
-    }
-  }, [selectedConfig, config]);
-
-  useEffect(() => {
-    if (
-      (isSet(config.newValue) && config.newValue !== config.default) ||
-      (!isSet(config.newValue) && config.value !== config.default)
-    ) {
-      setShowUseDefault(true);
-    } else {
-      setShowUseDefault(false);
-    }
-
-    if (isSet(config.newValue) && config.newValue !== config.value) {
-      setInputChanged(true);
-    } else {
-      setInputChanged(false);
-    }
-  }, [config]);
-
   function handleOptionChange(e: any) {
     const bool = e.target.value === "true" ? true : false;
     setNewValue(e.target.name, bool);
   }
 
-  function resetToDefault() {
-    setNewValue(config.name, config.default);
-  }
-
   return (
-    // XXX How to tell aria to ignore the click but not the element?
-    // eslint-disable-next-line
-    <div
-      className={classnames("config-input", {
-        "config-input--focused": inputFocused,
-        "config-input--changed": inputChanged,
-      })}
-      onClick={() => setSelectedConfig(config)}
-    >
-      <h5 className="u-float-left">
-        <i
-          className={classnames("config-input--view-description", {
-            "p-icon--plus": !showDescription,
-            "p-icon--minus": showDescription,
-          })}
-          onClick={() => setShowDescription(!showDescription)}
-          onKeyPress={() => setShowDescription(!showDescription)}
-          role="button"
-          tabIndex={0}
-        />
-        {config.name}
-      </h5>
-      <button
-        className={classnames(
-          "u-float-right p-button--base config-panel__hide-button",
-          {
-            "config-panel__show-button": showUseDefault,
-          }
-        )}
-        onClick={resetToDefault}
-      >
-        use default
-      </button>
-      <div
-        className={classnames("config-input--description")}
-        ref={descriptionRef}
-      >
-        <pre className="config-input--description-container">
-          {config.description}
-        </pre>
-      </div>
-      <div className="row">
-        <div className="col-2">
-          <RadioInput
-            label="true"
-            name={config.name}
-            aria-labelledby={config.name}
-            checked={inputValue === true}
-            value="true"
-            onClick={handleOptionChange}
-            onChange={handleOptionChange}
-          />
+    <ConfigField<boolean>
+      config={config}
+      selectedConfig={selectedConfig}
+      setSelectedConfig={setSelectedConfig}
+      setNewValue={setNewValue}
+      input={(value) => (
+        <div className="row">
+          <div className="col-2">
+            <RadioInput
+              label="true"
+              name={config.name}
+              aria-labelledby={config.name}
+              checked={value === true}
+              value="true"
+              onClick={handleOptionChange}
+              onChange={handleOptionChange}
+            />
+          </div>
+          <div className="col-2">
+            <RadioInput
+              label="false"
+              name={config.name}
+              aria-labelledby={config.name}
+              checked={value === false}
+              value="false"
+              onClick={handleOptionChange}
+              onChange={handleOptionChange}
+            />
+          </div>
         </div>
-        <div className="col-2">
-          <RadioInput
-            label="false"
-            name={config.name}
-            aria-labelledby={config.name}
-            checked={inputValue === false}
-            value="false"
-            onClick={handleOptionChange}
-            onChange={handleOptionChange}
-          />
-        </div>
-      </div>
-    </div>
+      )}
+    />
   );
 }

--- a/src/panels/ConfigPanel/ConfigField.tsx
+++ b/src/panels/ConfigPanel/ConfigField.tsx
@@ -1,0 +1,141 @@
+import { ReactNode, useEffect, useRef, useState } from "react";
+import classnames from "classnames";
+
+import { isSet } from "components/utils";
+import { ConfigData } from "juju/api";
+
+export type SetNewValue = (name: string, value: any) => void;
+
+export type ConfigProps = {
+  config: ConfigData;
+  selectedConfig: ConfigData | undefined;
+  setSelectedConfig: Function;
+  setNewValue: SetNewValue;
+};
+
+type Props<V> = ConfigProps & {
+  input: (value: V) => ReactNode;
+};
+
+const ConfigField = <V,>({
+  config,
+  input,
+  selectedConfig,
+  setSelectedConfig,
+  setNewValue,
+}: Props<V>): JSX.Element => {
+  const [inputFocused, setInputFocused] = useState(false);
+  const [inputChanged, setInputChanged] = useState(false);
+  const [showUseDefault, setShowUseDefault] = useState(
+    config.value !== config.default
+  );
+  const [showDescription, setShowDescription] = useState(false);
+  const descriptionRef = useRef<HTMLDivElement>(null);
+  const [maxDescriptionHeight, setMaxDescriptionHeight] = useState("0px");
+
+  let inputValue = config.default;
+  if (isSet(config.newValue)) {
+    inputValue = config.newValue;
+  } else if (config.default !== config.value) {
+    inputValue = config.value;
+  }
+
+  useEffect(() => {
+    if (descriptionRef.current?.firstChild) {
+      setMaxDescriptionHeight(
+        `${
+          (descriptionRef.current.firstChild as HTMLPreElement).clientHeight
+        }px`
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!descriptionRef.current) {
+      return;
+    }
+    if (showDescription) {
+      descriptionRef.current.style.maxHeight = maxDescriptionHeight;
+    } else {
+      descriptionRef.current.style.maxHeight = "0px";
+    }
+  }, [showDescription, maxDescriptionHeight]);
+
+  useEffect(() => {
+    setInputFocused(selectedConfig?.name === config.name);
+  }, [selectedConfig, config]);
+
+  useEffect(() => {
+    if (
+      (isSet(config.newValue) && config.newValue !== config.default) ||
+      (!isSet(config.newValue) && config.value !== config.default)
+    ) {
+      setShowUseDefault(true);
+    } else {
+      setShowUseDefault(false);
+    }
+
+    if (isSet(config.newValue) && config.newValue !== config.value) {
+      setInputChanged(true);
+    } else {
+      setInputChanged(false);
+    }
+  }, [config]);
+
+  function resetToDefault() {
+    setNewValue(config.name, config.default);
+  }
+
+  function handleShowDescription() {
+    setShowDescription(!showDescription);
+  }
+
+  return (
+    // XXX How to tell aria to ignore the click but not the element?
+    // eslint-disable-next-line
+    <div
+      className={classnames("config-input", {
+        "config-input--focused": inputFocused,
+        "config-input--changed": inputChanged,
+      })}
+      data-testid={config.name}
+      onClick={() => setSelectedConfig(config)}
+    >
+      <h5 className="u-float-left">
+        <i
+          className={classnames("config-input--view-description", {
+            "p-icon--plus": !showDescription,
+            "p-icon--minus": showDescription,
+          })}
+          onClick={handleShowDescription}
+          onKeyPress={handleShowDescription}
+          role="button"
+          tabIndex={0}
+        />
+        {config.name}
+      </h5>
+      <button
+        className={classnames(
+          "u-float-right p-button--base config-panel__hide-button",
+          {
+            "config-panel__show-button": showUseDefault,
+          }
+        )}
+        onClick={resetToDefault}
+      >
+        use default
+      </button>
+      <div
+        className={classnames("config-input--description")}
+        ref={descriptionRef}
+      >
+        <pre className="config-input--description-container">
+          {config.description}
+        </pre>
+      </div>
+      {input(inputValue)}
+    </div>
+  );
+};
+
+export default ConfigField;

--- a/src/panels/ConfigPanel/ConfigPanel.tsx
+++ b/src/panels/ConfigPanel/ConfigPanel.tsx
@@ -9,7 +9,11 @@ import {
 import { ReactNode, useEffect, useState } from "react";
 import type { Store } from "redux";
 
-import { Spinner, useListener } from "@canonical/react-components";
+import {
+  Notification,
+  Spinner,
+  useListener,
+} from "@canonical/react-components";
 
 import FadeIn from "animations/FadeIn";
 import { generateIconImg, isSet } from "components/utils";
@@ -26,6 +30,8 @@ import BooleanConfig from "./BooleanConfig";
 import TextAreaConfig from "./TextAreaConfig";
 
 import "./_config-panel.scss";
+import { SetNewValue } from "./ConfigField";
+import NumberConfig from "./NumberConfig";
 
 export enum Label {
   NONE = "This application doesn't have any configuration parameters",
@@ -38,16 +44,14 @@ type Props = {
   onClose: () => void;
 };
 
-export type ConfigProps = {
-  config: ConfigData;
-  selectedConfig: ConfigData | undefined;
-  setSelectedConfig: Function;
-  setNewValue: SetNewValue;
-};
-
-type SetNewValue = (name: string, value: any) => void;
-
 type ConfirmTypes = "apply" | "cancel" | null;
+
+const generateErrors = (errors: string[]) =>
+  errors.map((error) => (
+    <Notification key={error} severity="negative">
+      {error}
+    </Notification>
+  ));
 
 export default function ConfigPanel({
   appName,
@@ -65,6 +69,7 @@ export default function ConfigPanel({
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [savingConfig, setSavingConfig] = useState<boolean>(false);
   const [confirmType, setConfirmType] = useState<ConfirmTypes>(null);
+  const [formErrors, setFormErrors] = useState<string[] | null>(null);
 
   const sendAnalytics = useAnalytics();
 
@@ -167,16 +172,24 @@ export default function ConfigPanel({
 
   async function _submitToJuju() {
     setSavingConfig(true);
-    const error = await setApplicationConfig(
+    const response = await setApplicationConfig(
       modelUUID,
       appName,
       config,
       reduxStore.getState()
     );
-    // It returns an empty object if it's successful.
-    if (typeof error === "string") {
-      // XXX Surface this to the user.
-      console.error("error setting config", error);
+    let errors = response?.results?.reduce<string[]>((collection, result) => {
+      if (result.error) {
+        collection.push(result.error.message);
+      }
+      return collection;
+    }, []);
+    setSavingConfig(false);
+    setEnableSave(false);
+    setConfirmType(null);
+    if (errors.length) {
+      setFormErrors(errors);
+      return;
     }
     await getConfig(
       modelUUID,
@@ -186,9 +199,6 @@ export default function ConfigPanel({
       setConfig,
       checkAllDefaults
     );
-    setSavingConfig(false);
-    setEnableSave(false);
-    setConfirmType(null);
     sendAnalytics({
       category: "User",
       action: "Config values updated",
@@ -205,6 +215,8 @@ export default function ConfigPanel({
           changedConfigList,
           () => {
             setConfirmType(null);
+            // Clear the form errors if there were any from a previous submit.
+            setFormErrors(null);
             _submitToJuju();
           },
           () => setConfirmType(null)
@@ -278,6 +290,7 @@ export default function ConfigPanel({
                 </div>
 
                 <div className="config-panel__list">
+                  {formErrors ? generateErrors(formErrors) : null}
                   {generateConfigElementList(
                     config,
                     selectedConfig,
@@ -381,6 +394,16 @@ function generateConfigElementList(
     if (config.type === "boolean") {
       return (
         <BooleanConfig
+          key={config.name}
+          config={config}
+          selectedConfig={selectedConfig}
+          setSelectedConfig={setSelectedConfig}
+          setNewValue={setNewValue}
+        />
+      );
+    } else if (config.type === "int") {
+      return (
+        <NumberConfig
           key={config.name}
           config={config}
           selectedConfig={selectedConfig}

--- a/src/panels/ConfigPanel/NumberConfig.tsx
+++ b/src/panels/ConfigPanel/NumberConfig.tsx
@@ -1,30 +1,29 @@
-import { useRef } from "react";
 import ConfigField, { ConfigProps } from "./ConfigField";
 
-export default function TextAreaConfig({
+const NumberConfig = ({
   config,
   selectedConfig,
   setSelectedConfig,
   setNewValue,
-}: ConfigProps): JSX.Element {
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-
+}: ConfigProps): JSX.Element => {
   return (
-    <ConfigField<string>
+    <ConfigField<number>
       config={config}
       selectedConfig={selectedConfig}
       setSelectedConfig={setSelectedConfig}
       setNewValue={setNewValue}
       input={(value) => (
-        <textarea
-          ref={inputRef}
+        <input
+          type="number"
           value={value}
           onFocus={() => setSelectedConfig(config)}
           onChange={(e) => {
             setNewValue(config.name, e.target.value);
           }}
-        ></textarea>
+        />
       )}
     />
   );
-}
+};
+
+export default NumberConfig;


### PR DESCRIPTION
## Done

- Display config API errors
- Dedupe config field shared code.
- Add number field.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Open the config panel for an app with a number config and check that it appears as a number field and that you can't input text.
- The easiest way to get a config error seems to be to inspect a number input and change its type to text and then enter in some non number characters. Save the form and it should display the errors at the top of the form.

## Details

Fixes: #849.
https://warthogs.atlassian.net/browse/WD-2459

## Screenshots

<img width="501" alt="Screenshot 2023-03-07 at 2 46 53 pm" src="https://user-images.githubusercontent.com/361637/223591443-8599a0c5-bc02-45d7-88f7-e2cf541010b7.png">

