### PR TITLE
WD-2514 - Fix config title truncation

### DIFF
--- a/src/panels/ConfigPanel/ConfigPanel.tsx
+++ b/src/panels/ConfigPanel/ConfigPanel.tsx
@@ -259,17 +259,17 @@ export default function ConfigPanel({
             <>
               <div className="config-panel__config-list col-6">
                 <div className="config-panel__list-header">
-                  <div className="entity-name">
+                  <h4 className="entity-name">
                     {generateIconImg(appName, charm)} {appName}
-                  </div>
-                  <div className="config-panel__reset-all">
+                  </h4>
+                  <div
+                    className={classnames("config-panel__reset-all", {
+                      "config-panel__hide-button": !showResetAll,
+                      "config-panel__show-button": showResetAll,
+                    })}
+                  >
                     <button
-                      className={classnames(
-                        "u-button-neutral config-panel__hide-button",
-                        {
-                          "config-panel__show-button": showResetAll,
-                        }
-                      )}
+                      className="u-button-neutral"
                       onClick={allFieldsToDefault}
                     >
                       Reset all values

--- a/src/panels/ConfigPanel/_config-panel.scss
+++ b/src/panels/ConfigPanel/_config-panel.scss
@@ -58,7 +58,15 @@
   }
 
   &__reset-all {
+    flex: 1 0 auto;
     margin-left: auto;
+
+    &.config-panel__hide-button {
+      overflow: hidden;
+      position: absolute;
+      right: 1.5rem;
+      top: 0;
+    }
   }
 
   &__message {
@@ -78,11 +86,11 @@
   }
 
   &__list-header {
-    align-items: baseline;
     display: flex;
     justify-content: space-between;
     margin: 2rem 0 1rem;
     padding: 0 1.5rem;
+    position: relative;
 
     @media (max-width: $breakpoint-x-small) {
       flex-direction: column;
@@ -107,11 +115,13 @@
     }
 
     .entity-name {
-      font-size: 1.3rem;
-      margin-top: 0.3rem;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+
+      .entity-icon {
+        vertical-align: text-bottom;
+      }
     }
   }
 


### PR DESCRIPTION
## Done

- Only truncate the config panel title when the reset button is visible.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- [Add additional steps]

## Details

Fixes: #1408.
https://warthogs.atlassian.net/browse/WD-2514

## Screenshots

![Screen Recording 2023-03-08 at 3 12 05 pm](https://user-images.githubusercontent.com/361637/223618007-6636fc9b-25ab-4248-89fc-b5a3ce51500f.gif)

