### PR TITLE
Fix the actions help

### DIFF
--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -345,7 +345,7 @@ export default function ShareModel() {
                     write
                     <span className="help-text">
                       In addition to 'read' abilities, a user can
-                      modify/configure models
+                      modify/configure models and execute actions.
                     </span>
                   </>
                 }
@@ -359,8 +359,8 @@ export default function ShareModel() {
                     admin
                     <span className="help-text">
                       In addition to 'write' abilities, a user can perform model
-                      upgrades, execute actions and connect to machines via juju
-                      ssh. Makes the user an effective model owner.
+                      upgrades and connect to machines via juju ssh. Makes the
+                      user an effective model owner.
                     </span>
                   </>
                 }


### PR DESCRIPTION
## Done

- Move the actions help to 'write' instead of 'admin'.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Open the access panel for a model.
- Under the **write** option (instead of admin) it should have the help about executing actions.

## Details

Fixes: #1037.

## Screenshots

<img width="268" alt="Screenshot 2023-03-09 at 10 04 14 am" src="https://user-images.githubusercontent.com/361637/223872310-6f84301f-3aa2-499a-8e15-bce308898b8b.png">

