### PR TITLE
Fix resizing the CLI on mobile

### DIFF
--- a/src/components/WebCLI/WebCLI.tsx
+++ b/src/components/WebCLI/WebCLI.tsx
@@ -8,7 +8,7 @@ import { Credential } from "store/general/types";
 
 import useAnalytics from "../../hooks/useAnalytics";
 
-import WebCLIOutput from "./Output.js";
+import WebCLIOutput from "./Output";
 
 import Connection from "./connection";
 

--- a/src/components/WebCLI/_webcli.scss
+++ b/src/components/WebCLI/_webcli.scss
@@ -66,8 +66,12 @@ $canonical-purple: #2c001e;
   &__output {
     background-color: $canonical-purple;
     height: 300px;
-    min-height: $webcli-drag-height;
+    min-height: $webcli-desktop-drag-height;
     overflow: hidden;
+
+    @media (max-width: $breakpoint-large) {
+      min-height: $webcli-mobile-drag-height;
+    }
 
     a {
       text-decoration: underline;
@@ -91,7 +95,7 @@ $canonical-purple: #2c001e;
 
     &-dragarea {
       cursor: row-resize;
-      height: $webcli-drag-height;
+      height: $webcli-desktop-drag-height;
       user-select: none;
       width: 100%;
     }
@@ -104,6 +108,12 @@ $canonical-purple: #2c001e;
       right: 50%;
       top: 0;
       width: 2rem;
+    }
+  }
+
+  .webcli__output-dragarea {
+    @media (max-width: $breakpoint-large) {
+      height: $webcli-mobile-drag-height;
     }
   }
 }

--- a/src/layout/BaseLayout/_base-layout.scss
+++ b/src/layout/BaseLayout/_base-layout.scss
@@ -126,7 +126,11 @@
 }
 
 .l-content--has-webcli {
-  margin-bottom: calc(1rem + #{$webcli-height});
+  margin-bottom: calc(1rem + #{$webcli-desktop-height});
+
+  @media (max-width: $breakpoint-large) {
+    margin-bottom: calc(1rem + #{$webcli-mobile-height});
+  }
 }
 
 .l-application {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,6 +1,8 @@
 $top-header-height: 4rem;
 $webcli-input-height: 2.5rem;
 $webcli-desktop-drag-height: 10px;
+// The mobile drag element needs to be large so that it is not covered by the
+// input hit area.
 $webcli-mobile-drag-height: 25px;
 $webcli-desktop-height: calc(
   #{$webcli-input-height} + #{$webcli-desktop-drag-height}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -1,4 +1,10 @@
 $top-header-height: 4rem;
 $webcli-input-height: 2.5rem;
-$webcli-drag-height: 10px;
-$webcli-height: calc(#{$webcli-input-height} + #{$webcli-drag-height});
+$webcli-desktop-drag-height: 10px;
+$webcli-mobile-drag-height: 25px;
+$webcli-desktop-height: calc(
+  #{$webcli-input-height} + #{$webcli-desktop-drag-height}
+);
+$webcli-mobile-height: calc(
+  #{$webcli-input-height} + #{$webcli-mobile-drag-height}
+);


### PR DESCRIPTION
## Done

- Migrate the output component to TypeScript.
- Update the mobile CLI drag to use the correct event names and also make the hit area larger so that it's not covered by the larger input hit area.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Navigate to a model (needs to be a local controller so the CLI appears).
- With your browser set to desktop width check that you can resize the CLI output.
- Resize down to tablet or mobile size.
- Open the dev tools and turn on device simulation (the little mobile/tablet icon).
- Check that you can resize the CLI output.

## Details

[List of links to issues/bugs and cards if needed]

## Screenshots

[if relevant, include a screenshot]
