### PR TITLE
WD-2611 - Link entity icons to model tabs

### DIFF
--- a/src/components/ModelTableList/CloudGroup.js
+++ b/src/components/ModelTableList/CloudGroup.js
@@ -89,11 +89,9 @@ export default function CloudGroup({ filters }) {
         const { highestStatus } = getModelStatusGroupData(model);
         const owner = extractOwnerName(model.info["owner-tag"]);
         const region = getStatusValue(model, "region");
-        const credential = getStatusValue(model.info, "cloud-credential-tag");
-        const controller = getStatusValue(model.info, "controllerName");
-        const lastUpdated = getStatusValue(model.info, "status.since")?.slice(
-          2
-        );
+        const credential = getStatusValue(model, "cloud-credential-tag");
+        const controller = getStatusValue(model, "controllerName");
+        const lastUpdated = getStatusValue(model, "status.since")?.slice(2);
         cloudModels.rows.push({
           "data-testid": `model-uuid-${model?.uuid}`,
           columns: [
@@ -107,7 +105,11 @@ export default function CloudGroup({ filters }) {
             },
             {
               "data-testid": "column-summary",
-              content: getStatusValue(model, "summary"),
+              content: getStatusValue(
+                model,
+                "summary",
+                model.info?.["owner-tag"]
+              ),
               className: "u-overflow--visible",
             },
             {

--- a/src/components/ModelTableList/OwnerGroup.js
+++ b/src/components/ModelTableList/OwnerGroup.js
@@ -86,11 +86,9 @@ export default function OwnerGroup({ filters }) {
       modelGroup.forEach((model) => {
         const { highestStatus } = getModelStatusGroupData(model);
         const cloud = generateCloudCell(model);
-        const credential = getStatusValue(model.info, "cloud-credential-tag");
-        const controller = getStatusValue(model.info, "controllerName");
-        const lastUpdated = getStatusValue(model.info, "status.since")?.slice(
-          2
-        );
+        const credential = getStatusValue(model, "cloud-credential-tag");
+        const controller = getStatusValue(model, "controllerName");
+        const lastUpdated = getStatusValue(model, "status.since")?.slice(2);
         ownerModels.rows.push({
           "data-testid": `model-uuid-${model?.uuid}`,
           columns: [
@@ -104,7 +102,11 @@ export default function OwnerGroup({ filters }) {
             },
             {
               "data-testid": "column-summary",
-              content: getStatusValue(model, "summary"),
+              content: getStatusValue(
+                model,
+                "summary",
+                model.info?.["owner-tag"]
+              ),
               className: "u-overflow--visible",
             },
             {

--- a/src/components/ModelTableList/StatusGroup.js
+++ b/src/components/ModelTableList/StatusGroup.js
@@ -116,11 +116,11 @@ function generateModelTableDataByStatus(groupedModels, setPanelQs, activeUser) {
         owner = extractOwnerName(model.info["owner-tag"]);
       }
       const cloud = generateCloudCell(model);
-      const credential = getStatusValue(model.info, "cloud-credential-tag");
-      const controller = getStatusValue(model.info, "controllerName");
+      const credential = getStatusValue(model, "cloud-credential-tag");
+      const controller = getStatusValue(model, "controllerName");
       // .slice(2) here will make the year 2 characters instead of 4
       // e.g. 2021-01-01 becomes 21-01-01
-      const lastUpdated = getStatusValue(model.info, "status.since")?.slice(2);
+      const lastUpdated = getStatusValue(model, "status.since")?.slice(2);
       modelData[`${groupLabel}Rows`].push({
         "data-testid": `model-uuid-${model?.uuid}`,
         columns: [
@@ -130,7 +130,11 @@ function generateModelTableDataByStatus(groupedModels, setPanelQs, activeUser) {
           },
           {
             "data-testid": "column-summary",
-            content: getStatusValue(model, "summary"),
+            content: getStatusValue(
+              model,
+              "summary",
+              model.info?.["owner-tag"]
+            ),
             className: "u-overflow--visible",
           },
           {

--- a/src/components/ModelTableList/shared.tsx
+++ b/src/components/ModelTableList/shared.tsx
@@ -1,23 +1,33 @@
+import { ReactNode } from "react";
+import { Link } from "react-router-dom";
+
 import awsLogo from "static/images/logo/cloud/aws.svg";
 import azureLogo from "static/images/logo/cloud/azure.svg";
 import gceLogo from "static/images/logo/cloud/gce.svg";
 import kubernetesLogo from "static/images/logo/cloud/kubernetes.svg";
+import { ModelData, ModelDataWithControllerName } from "store/juju/types";
 
-import { Link } from "react-router-dom";
 import {
   extractCloudName,
   extractCredentialName,
 } from "store/juju/utils/models";
+import { QueryParamConfig, SetQuery } from "use-query-params";
 
 /**
   Generates the model details link for the table cell. If no ownerTag can be
   provided then it'll return raw text for the model name.
-  @param {String} modelName The name of the model.
-  @param {String} ownerTag The ownerTag of the model.
-  @param {String} label The contents of the link.
-  @returns {Object} The React component for the link.
+  @param modelName The name of the model.
+  @param ownerTag The ownerTag of the model.
+  @param label The contents of the link.
+  @returns The React component for the link.
 */
-export function generateModelDetailsLink(modelName, ownerTag, label) {
+export function generateModelDetailsLink(
+  modelName: string,
+  ownerTag: string,
+  label: ReactNode,
+  view?: string,
+  className?: string
+) {
   // Because we get some data at different times based on the multiple API calls
   // we need to check for their existence and supply reasonable fallbacks if it
   // isn't available. Once we have a single API call for all the data this check
@@ -29,23 +39,34 @@ export function generateModelDetailsLink(modelName, ownerTag, label) {
   }
   // If the owner isn't the logged in user then we need to use the
   // fully qualified path name.
-  const modelDetailsPath = `/models/${ownerTag.replace(
+  let modelDetailsPath = `/models/${ownerTag.replace(
     "user-",
     ""
   )}/${modelName}`;
-  return <Link to={modelDetailsPath}>{label}</Link>;
+  if (view) {
+    modelDetailsPath = `${modelDetailsPath}?activeView=${view}`;
+  }
+  return (
+    <Link to={modelDetailsPath} className={className}>
+      {label}
+    </Link>
+  );
 }
 
 /**
   Used to fetch the values from status as it won't be defined when the
   modelInfo data is.
-  @param {Object|undefined} status The status for the model.
-  @param {String} key The key to fetch.
-  @returns {String} The computed value for the requested field if defined, or
+  @param status The status for the model.
+  @param key The key to fetch.
+  @returns The computed value for the requested field if defined, or
     an empty string.
 */
-export function getStatusValue(status, key) {
-  let returnValue = "";
+export function getStatusValue(
+  status: ModelDataWithControllerName,
+  key: string,
+  extra?: string
+) {
+  let returnValue: ReactNode = "";
   if (typeof status === "object" && status !== null) {
     switch (key) {
       case "summary":
@@ -64,16 +85,24 @@ export function getStatusValue(status, key) {
                 className="u-flex--block p-tooltip--top-center"
                 aria-describedby="tp-cntr"
               >
-                <div className="has-icon">
-                  <i className="p-icon--applications"></i>
-                  <span>{applicationCount}</span>
-                </div>
+                {extra
+                  ? generateModelDetailsLink(
+                      status.model.name,
+                      extra,
+                      <div className="has-icon">
+                        <i className="p-icon--applications"></i>
+                        <span>{applicationCount}</span>
+                      </div>,
+                      "apps",
+                      "p-link--soft"
+                    )
+                  : null}
                 <span
                   className="p-tooltip__message"
                   role="tooltip"
                   id="tp-cntr"
                 >
-                  Applications
+                  See applications
                 </span>
               </div>
               <div
@@ -96,16 +125,24 @@ export function getStatusValue(status, key) {
                 className="u-flex--block p-tooltip--top-center"
                 aria-describedby="tp-cntr"
               >
-                <div className="has-icon">
-                  <i className="p-icon--machines"></i>
-                  <span>{machineCount}</span>
-                </div>
+                {extra
+                  ? generateModelDetailsLink(
+                      status.model.name,
+                      extra,
+                      <div className="has-icon">
+                        <i className="p-icon--machines"></i>
+                        <span>{machineCount}</span>
+                      </div>,
+                      "machines",
+                      "p-link--soft"
+                    )
+                  : null}
                 <span
                   className="p-tooltip__message"
                   role="tooltip"
                   id="tp-cntr"
                 >
-                  Machines
+                  See machines
                 </span>
               </div>
             </div>
@@ -119,16 +156,18 @@ export function getStatusValue(status, key) {
         returnValue = status.model.region;
         break;
       case "cloud-credential-tag":
-        returnValue = extractCredentialName(status["cloud-credential-tag"]);
+        returnValue = extractCredentialName(
+          status.info?.["cloud-credential-tag"]
+        );
         break;
       case "controllerUuid":
-        returnValue = status["controller-uuid"];
+        returnValue = status.info?.["controller-uuid"];
         break;
       case "controllerName":
-        returnValue = status.controllerName;
+        returnValue = status.info?.controllerName;
         break;
       case "status.since":
-        returnValue = status.status.since?.split("T")[0];
+        returnValue = status.info?.status?.since?.split("T")[0];
         break;
       default:
         console.log(`unsupported status value key: ${key}`);
@@ -140,10 +179,10 @@ export function getStatusValue(status, key) {
 
 /**
   Generates the cloud and region info from model data.
-  @param {Object} model The model data.
-  @returns {Object} The React element for the model cloud and region cell.
+  @param model The model data.
+  @returns The React element for the model cloud and region cell.
 */
-export function generateCloudCell(model) {
+export function generateCloudCell(model: ModelData) {
   let provider = model?.info?.["provider-type"];
   let logo = null;
   switch (provider) {
@@ -201,10 +240,10 @@ export function generateCloudCell(model) {
 
 /**
   Returns the model cloud and region data formatted as {cloud}/{region}.
-  @param {Object} model The model data
-  @returns {String} The formatted cloud and region data.
+  @param model The model data
+  @returns The formatted cloud and region data.
 */
-export function generateCloudAndRegion(model) {
+export function generateCloudAndRegion(model: ModelData) {
   return `${getStatusValue(model, "cloud-tag")}/${getStatusValue(
     model,
     "region"
@@ -214,10 +253,18 @@ export function generateCloudAndRegion(model) {
 /**
   Returns the model access button or an alternative value
   @param {Function} setPanelQs A function to set query strings
-  @param {String} modelName the name of the model
-  @returns {Object} The markup for the table cell
+  @param modelName the name of the model
+  @returns The markup for the table cell
 */
-export function generateAccessButton(setPanelQs, modelName) {
+export function generateAccessButton(
+  setPanelQs: SetQuery<
+    Record<
+      string,
+      QueryParamConfig<string | null | undefined, string | null | undefined>
+    >
+  >,
+  modelName: string
+) {
   return (
     <button
       onClick={() => {

--- a/src/store/juju/types.ts
+++ b/src/store/juju/types.ts
@@ -40,6 +40,10 @@ export type ModelData = {
   uuid: string;
 };
 
+export type ModelDataWithControllerName = Omit<ModelData, "info"> & {
+  info?: ModelInfo & { controllerName?: string };
+};
+
 export type ModelDataList = Record<string, ModelData>;
 
 export type ModelListInfo = {


### PR DESCRIPTION
## Done

- Link entity icons to model tabs.
- Migrate shared file to TypeScript.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to the model list.
- Check that you can click on the app or machine icons and that they take you to the appropriate tab.

## Details

Fixes: #596.
https://warthogs.atlassian.net/browse/WD-2611

## Screenshots

<img width="457" alt="Screenshot 2023-03-14 at 3 24 18 pm" src="https://user-images.githubusercontent.com/361637/224893446-455440c1-a9aa-41bd-b836-ddba65703253.png">

