### PR TITLE
Show dashboard notification update icon

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -1,8 +1,9 @@
-import { StatusLabel } from "@canonical/react-components";
+import { dashboardUpdateAvailable } from "@canonical/jujulib/dist/api/versions";
+import { Icon, StatusLabel, Tooltip } from "@canonical/react-components";
 import classNames from "classnames";
 import Logo from "components/Logo/Logo";
 import UserMenu from "components/UserMenu/UserMenu";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { NavLink } from "react-router-dom";
 import { getAppVersion } from "store/general/selectors";
@@ -71,6 +72,12 @@ const ControllersLink = () => {
 
 const PrimaryNav = () => {
   const appVersion = useSelector(getAppVersion);
+  const [updateAvailable, setUpdateAvailable] = useState(false);
+
+  dashboardUpdateAvailable(appVersion || "").then((e) => {
+    setUpdateAvailable(e);
+  });
+
   return (
     <nav className="p-primary-nav">
       <div className="p-primary-nav__header">
@@ -104,7 +111,14 @@ const PrimaryNav = () => {
       <div className="p-primary-nav__bottom hide-collapsed">
         <ul className="p-list">
           <li className="p-list__item">
-            <span className="version">Version {appVersion}</span>
+            <span className="version">
+              Version {appVersion}{" "}
+              {updateAvailable && (
+                <Tooltip message="A new version of the dashboard is available.">
+                  <Icon name="warning" data-testid="dashboard-update" />
+                </Tooltip>
+              )}
+            </span>
             <StatusLabel appearance="positive">Beta</StatusLabel>
           </li>
         </ul>

--- a/src/pages/ControllersIndex/ControllersIndex.test.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.test.tsx
@@ -101,10 +101,6 @@ describe("Controllers table", () => {
   });
 
   it("Indicates if a controller has an update available", () => {
-    jest.mock("@canonical/jujulib/dist/api/versions", () => ({
-      jujuUpdateAvailable: jest.fn().mockResolvedValue(true),
-    }));
-
     state.juju = jujuStateFactory.build({
       controllers: {
         "wss://jimm.jujucharms.com/api": [


### PR DESCRIPTION
## Done

- Show an warning icon when a new version of the dashboard is available
 
## QA

- Pull code
- Change the version in the `package.json` to an old version
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Make sure that there is a warning icon in the nav bar

## Details

https://warthogs.atlassian.net/browse/WD-2529

## Screenshots
![image](https://user-images.githubusercontent.com/36013798/225059413-00507df8-0ca3-4f57-92e7-ddf160c4f22f.png)