### PR TITLE
WD-2612 - Add links to apps/units with errors

### DIFF
--- a/src/components/ModelTableList/StatusGroup.tsx
+++ b/src/components/ModelTableList/StatusGroup.tsx
@@ -106,7 +106,10 @@ const generateWarningMessage = (model: ModelData) => {
     list.push(`+${remainder.length} more...`);
   }
   return (
-    <Tooltip message={<List className="u-no-margin--bottom" items={list} />}>
+    <Tooltip
+      className="p-tooltip--constrain-width"
+      message={<List className="u-no-margin--bottom u-truncate" items={list} />}
+    >
       <span className="model-table-list_error-message">{link}</span>
     </Tooltip>
   );

--- a/src/components/ModelTableList/StatusGroup.tsx
+++ b/src/components/ModelTableList/StatusGroup.tsx
@@ -1,16 +1,28 @@
+import { ReactNode } from "react";
 import { useSelector } from "react-redux";
-import { MainTable } from "@canonical/react-components";
-import { useQueryParams, StringParam, withDefault } from "use-query-params";
+import { Link } from "react-router-dom";
+import { List, MainTable, Tooltip } from "@canonical/react-components";
+import { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import {
+  useQueryParams,
+  StringParam,
+  withDefault,
+  QueryParamConfig,
+  SetQuery,
+} from "use-query-params";
 import useActiveUser from "hooks/useActiveUser";
 
 import {
   getModelStatusGroupData,
   extractOwnerName,
   canAdministerModelAccess,
+  Filters,
+  Status,
 } from "store/juju/utils/models";
 import { generateStatusElement } from "components/utils";
 
 import { getGroupedByStatusAndFilteredModelData } from "store/juju/selectors";
+import { ModelData } from "store/juju/types";
 
 import {
   generateModelDetailsLink,
@@ -26,11 +38,11 @@ export const TestId = {
 
 /**
   Generates the table headers for the supplied table label.
-  @param {String} label The title of the table.
-  @param {Number} count The number of elements in the status.
-  @returns {Array} The headers for the table.
+  @param label The title of the table.
+  @param count The number of elements in the status.
+  @returns The headers for the table.
 */
-function generateStatusTableHeaders(label, count) {
+function generateStatusTableHeaders(label: string, count: number) {
   return [
     {
       content: generateStatusElement(label, count),
@@ -56,35 +68,61 @@ function generateStatusTableHeaders(label, count) {
 
 /**
   Generates the warning message for the model name cell.
-  @param {Object} model The full model data.
-  @return {Object} The react component for the warning message.
+  @param model The full model data.
+  @return The react component for the warning message.
 */
-const generateWarningMessage = (model) => {
+const generateWarningMessage = (model: ModelData) => {
   const { messages } = getModelStatusGroupData(model);
-  const title = messages.join("; ");
+  if (!messages.length) {
+    return null;
+  }
+  const ownerTag = model?.info?.["owner-tag"] ?? "";
   const link = generateModelDetailsLink(
     model.model.name,
-    model?.info?.ownerTag,
-    title
+    ownerTag,
+    messages[0].message
   );
+  const modelDetailsPath = `/models/${ownerTag.replace("user-", "")}/${
+    model.model.name
+  }`;
+  const list: ReactNode[] = messages.slice(0, 5).map((message) => (
+    <>
+      {message.unitId || message.appName}:{" "}
+      <Link
+        to={[
+          modelDetailsPath,
+          `app/${message.appName}`,
+          message.unitId ? `unit/${message.unitId.replace("/", "-")}` : null,
+        ]
+          .filter(Boolean)
+          .join("/")}
+      >
+        {message.message}
+      </Link>
+    </>
+  ));
+  const remainder = messages.slice(5);
+  if (remainder.length) {
+    list.push(`+${remainder.length} more...`);
+  }
   return (
-    <span className="model-table-list_error-message" title={title}>
-      {link}
-    </span>
+    <Tooltip message={<List className="u-no-margin--bottom" items={list} />}>
+      <span className="model-table-list_error-message">{link}</span>
+    </Tooltip>
   );
 };
 
 /**
   Generates the model name cell.
-  @param {Object} model The model data.
-  @param {String} groupLabel The status group the model belongs in.
+  @param model The model data.
+  @param groupLabel The status group the model belongs in.
     e.g. blocked, alert, running
-  @returns {Object} The React element for the model name cell.
+  @returns The React element for the model name cell.
 */
-const generateModelNameCell = (model, groupLabel) => {
+const generateModelNameCell = (model: ModelData, groupLabel: string) => {
   const link = generateModelDetailsLink(
     model.model.name,
-    model.info && model.info["owner-tag"],
+    model.info?.["owner-tag"] ?? "",
     model.model.name
   );
   return (
@@ -97,18 +135,27 @@ const generateModelNameCell = (model, groupLabel) => {
 
 /**
   Returns the model info and statuses in the proper format for the table data.
-  @param {Object} groupedModels The models grouped by state
-  @returns {Object} The formatted table data.
+  @param  groupedModels The models grouped by state
+  @return The formatted table data.
 */
-function generateModelTableDataByStatus(groupedModels, setPanelQs, activeUser) {
-  const modelData = {
+function generateModelTableDataByStatus(
+  groupedModels: Record<Status, ModelData[]>,
+  setPanelQs: SetQuery<
+    Record<
+      string,
+      QueryParamConfig<string | null | undefined, string | null | undefined>
+    >
+  >,
+  activeUser: string
+) {
+  const modelData: Record<string, MainTableRow[]> = {
     blockedRows: [],
     alertRows: [],
     runningRows: [],
   };
 
   Object.keys(groupedModels).forEach((groupLabel) => {
-    const models = groupedModels[groupLabel];
+    const models = groupedModels[groupLabel as Status];
 
     models.forEach((model) => {
       let owner = "";
@@ -118,9 +165,12 @@ function generateModelTableDataByStatus(groupedModels, setPanelQs, activeUser) {
       const cloud = generateCloudCell(model);
       const credential = getStatusValue(model, "cloud-credential-tag");
       const controller = getStatusValue(model, "controllerName");
-      // .slice(2) here will make the year 2 characters instead of 4
-      // e.g. 2021-01-01 becomes 21-01-01
-      const lastUpdated = getStatusValue(model, "status.since")?.slice(2);
+      let lastUpdated = getStatusValue(model, "status.since");
+      if (typeof lastUpdated === "string") {
+        // .slice(2) here will make the year 2 characters instead of 4
+        // e.g. 2021-01-01 becomes 21-01-01
+        lastUpdated = lastUpdated.slice(2);
+      }
       modelData[`${groupLabel}Rows`].push({
         "data-testid": `model-uuid-${model?.uuid}`,
         columns: [
@@ -189,14 +239,16 @@ function generateModelTableDataByStatus(groupedModels, setPanelQs, activeUser) {
           controller,
           lastUpdated,
         },
-      });
+        // TSFixMe this is required until react-components includes template
+        // literals for data properties.
+      } as MainTableRow);
     });
   });
 
   return modelData;
 }
 
-export default function StatusGroup({ filters }) {
+export default function StatusGroup({ filters }: { filters: Filters }) {
   const groupedAndFilteredData = useSelector(
     getGroupedByStatusAndFilteredModelData(filters)
   );

--- a/src/scss/_utils.scss
+++ b/src/scss/_utils.scss
@@ -42,3 +42,7 @@
   margin-right: 0.25rem;
   margin-top: 0.25rem;
 }
+
+.p-tooltip--constrain-width {
+  max-width: 20rem;
+}

--- a/src/store/juju/utils/models.ts
+++ b/src/store/juju/utils/models.ts
@@ -56,15 +56,18 @@ const checkHighestStatus = (highestStatus: Status) => {
 
 export const getModelStatusGroupData = (model: ModelData) => {
   let highestStatus = statusOrder[0]; // Set the highest status to the lowest.
-  let messages: string[] = [];
+  let messages: { message: string; appName: string; unitId?: string }[] = [];
   const applications = model.applications || {};
   Object.keys(applications).forEach((appName) => {
     const app = applications[appName];
     const { status: appStatus } = getApplicationStatusGroup(app);
     highestStatus = setHighestStatus(appStatus, highestStatus);
-    if (checkHighestStatus(highestStatus)) {
+    if (checkHighestStatus(appStatus)) {
       // If it's the highest status then we want to store the message.
-      messages.push(app.status.info);
+      messages.push({
+        appName,
+        message: app.status.info,
+      });
       return;
     }
     const units = app.units || {}; // subordinates do not have units.
@@ -72,9 +75,13 @@ export const getModelStatusGroupData = (model: ModelData) => {
       const unit = units[unitId];
       const { status: unitStatus } = getUnitStatusGroup(unit);
       highestStatus = setHighestStatus(unitStatus, highestStatus);
-      if (checkHighestStatus(highestStatus)) {
+      if (checkHighestStatus(unitStatus)) {
         // If it's the highest status then we want to store the message.
-        messages.push(unit["agent-status"].info);
+        messages.push({
+          appName,
+          unitId,
+          message: unit["agent-status"].info,
+        });
         return;
       }
     });


### PR DESCRIPTION
## Done

- Add links to apps/units with errors.
- Migrate StatusGroup to TypeScript.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- You'll need some units/apps in error (you could try changing the config options for an app to something invalid).
- Go to the model list and you should see the error in red under the model name.
- Hovering the error should show all the errors and clicking them should take you to the appropriate app/unit.

## Details

Fixes: #598.
https://warthogs.atlassian.net/browse/WD-2612

## Screenshots

<img width="530" alt="Screenshot 2023-03-14 at 4 58 52 pm" src="https://user-images.githubusercontent.com/361637/225180957-7cc86161-dfef-4aca-a928-ce2ad71008bc.png">
<img width="546" alt="Screenshot 2023-03-14 at 5 03 52 pm" src="https://user-images.githubusercontent.com/361637/225180965-658e81b3-9d4d-4542-8270-7b7b1e7115ee.png">

