### PR TITLE
WD-2639 - Fix revoking permissions

### DIFF
--- a/src/panels/ShareModelPanel/ShareModel.test.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.test.tsx
@@ -5,13 +5,17 @@ import { Provider } from "react-redux";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryParamProvider } from "use-query-params";
 import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
+import { actions as appActions } from "store/app";
 
+import { Label } from "components/ShareCard/ShareCard";
 import { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
 import {
   jujuStateFactory,
   modelDataFactory,
   modelDataInfoFactory,
+  modelUserInfoFactory,
+  controllerFactory,
 } from "testing/factories/juju/juju";
 
 import ShareModel from "./ShareModel";
@@ -21,13 +25,23 @@ const mockStore = configureStore([]);
 describe("Share Model Panel", () => {
   let state: RootState;
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   beforeEach(() => {
     state = rootStateFactory.build({
       juju: jujuStateFactory.build({
+        controllers: {
+          "wss://jimm.jujucharms.com/api": [
+            controllerFactory.build({ path: "admin/jaas", uuid: "123" }),
+          ],
+        },
         modelData: {
           abc123: modelDataFactory.build({
             info: modelDataInfoFactory.build({
               name: "hadoopspark",
+              users: [modelUserInfoFactory.build()],
             }),
           }),
         },
@@ -81,5 +95,37 @@ describe("Share Model Panel", () => {
       name: "Back",
     });
     expect(backToCardsButton).toBeInTheDocument();
+  });
+
+  it("can remove a user", async () => {
+    const updatePermissionsSpy = jest.spyOn(appActions, "updatePermissions");
+    const store = mockStore(state);
+    render(
+      <MemoryRouter initialEntries={["/models/eggman@external/hadoopspark"]}>
+        <Provider store={store}>
+          <QueryParamProvider adapter={ReactRouter6Adapter}>
+            <Routes>
+              <Route
+                path="/models/:userName/:modelName"
+                element={<ShareModel />}
+              />
+            </Routes>
+          </QueryParamProvider>
+        </Provider>
+      </MemoryRouter>
+    );
+    await userEvent.click(
+      screen.getByRole("button", {
+        name: Label.REMOVE,
+      })
+    );
+    expect(updatePermissionsSpy).toHaveBeenCalledWith({
+      action: "revoke",
+      modelUUID: "84e872ff-9171-46be-829b-70f0ffake18d",
+      permissionFrom: "read",
+      permissionTo: undefined,
+      user: "user-eggman@external",
+      wsControllerURL: "wss://jimm.jujucharms.com/api",
+    });
   });
 });

--- a/src/panels/ShareModelPanel/ShareModel.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.tsx
@@ -56,6 +56,7 @@ export default function ShareModel() {
   });
 
   const controllerUUID = modelStatusData?.info?.["controller-uuid"];
+
   const modelUUID = modelStatusData?.info?.uuid;
   const modelName = modelStatusData?.info?.name;
 
@@ -100,9 +101,6 @@ export default function ShareModel() {
     permissionTo: string | undefined,
     permissionFrom: string | undefined
   ) => {
-    if (!modelControllerURL || !modelUUID) {
-      return;
-    }
     let response: ErrorResults | null;
     if (!modelControllerURL || !modelUUID) {
       return;
@@ -180,7 +178,11 @@ export default function ShareModel() {
       "revoke",
       username,
       undefined,
-      usersAccess?.[username]
+      // When revoking permissions the user is dropped down a level from
+      // whatever permission is passed to the revoke command. As we want to
+      // remove the user entirely we need to revoke the lowest possible
+      // permission (which also revokes all higher permissions).
+      "read"
     );
 
     reactHotToast.custom((t) => (


### PR DESCRIPTION
## Done

- Revoke all permissions when removing a user from a model.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Add a user to a model with write or admin permissions.
- Go to the access panel for that model and click the delete button to remove the user.
- Refresh the window and check that the user does not reappear with permissions one level lower than their previous.

## Details

Fixes: #1038.
https://warthogs.atlassian.net/browse/WD-2639

