### PR TITLE
WD-2640 - Fix resizing the header

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.test.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.test.tsx
@@ -77,4 +77,20 @@ describe("ButtonGroup", () => {
     );
     expect(screen.queryByTestId(TestId.LABEL)).not.toBeInTheDocument();
   });
+
+  it("can set the label to not wrap", () => {
+    const setActiveButton = jest.fn();
+    render(
+      <ButtonGroup
+        activeButton="cloud"
+        buttons={["status", "cloud", "owner"]}
+        label="Foo"
+        noWrap
+        setActiveButton={setActiveButton}
+      />
+    );
+    expect(screen.queryByTestId(TestId.LABEL)).toHaveClass(
+      "p-button-group__label--fixed"
+    );
+  });
 });

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -9,6 +9,7 @@ export enum TestId {
 type Props = {
   buttons: string[];
   label?: string;
+  noWrap?: boolean;
   activeButton: string;
   setActiveButton: (value: string) => void;
 };
@@ -16,6 +17,7 @@ type Props = {
 const ButtonGroup = ({
   buttons,
   label,
+  noWrap,
   activeButton,
   setActiveButton,
 }: Props): JSX.Element => {
@@ -23,7 +25,12 @@ const ButtonGroup = ({
     <div className="p-button-group">
       <div className="p-button-group__inner">
         {label ? (
-          <span className="p-button-group__label" data-testid={TestId.LABEL}>
+          <span
+            className={classNames("p-button-group__label", {
+              "p-button-group__label--fixed": noWrap,
+            })}
+            data-testid={TestId.LABEL}
+          >
             {label}
           </span>
         ) : null}

--- a/src/components/ButtonGroup/_button-group.scss
+++ b/src/components/ButtonGroup/_button-group.scss
@@ -13,6 +13,10 @@
     @media (max-width: 768px) {
       display: none;
     }
+
+    &--fixed {
+      white-space: nowrap;
+    }
   }
 
   &__buttons {

--- a/src/pages/ModelsIndex/ModelsIndex.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.tsx
@@ -145,6 +145,7 @@ export default function Models() {
             activeButton={groupModelsBy}
             buttons={["status", "cloud", "owner"]}
             label="Group by:"
+            noWrap
             setActiveButton={setGroupModelsBy}
           />
           <SearchAndFilter

--- a/src/pages/ModelsIndex/_models.scss
+++ b/src/pages/ModelsIndex/_models.scss
@@ -29,7 +29,8 @@
     }
 
     @media (min-width: $breakpoint-large) {
-      grid-template-columns: 120px 1fr 280px;
+      // Account for the 1.5rem padding applied to the header.
+      grid-template-columns: calc(120px - 1.5rem) 1fr calc(280px - 1.5rem);
     }
 
     .search-and-filter {

--- a/src/pages/ModelsIndex/_models.scss
+++ b/src/pages/ModelsIndex/_models.scss
@@ -15,9 +15,11 @@
       pointer-events: none;
     }
 
-    @media (max-width: $breakpoint-large) {
-      .models__count {
-        display: none;
+    .models__count {
+      display: none;
+
+      @media (min-width: $breakpoint-large) {
+        display: block;
       }
     }
 


### PR DESCRIPTION
## Done

- Fix the header at all sizes.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to the model list.
- Resize your window down to mobile and check that the header doesn't break at any size.
- Resize your viewport to exactly 1036px and check that it doesn't break like the following screenshot:
<img width="1034" alt="Screenshot 2023-03-15 at 4 03 02 pm" src="https://user-images.githubusercontent.com/361637/225222045-dbea0a65-406a-4c4e-b218-fb243ee19428.png">


## Details

Fixes: #974.
https://warthogs.atlassian.net/browse/WD-2640

## Screenshots
<img width="1037" alt="Screenshot 2023-03-15 at 5 08 19 pm" src="https://user-images.githubusercontent.com/361637/225221680-09a7ead7-b213-49e5-b0f9-a4ad49fe7be8.png">


