### PR TITLE
WD-2663 - Fix lockup

### DIFF
--- a/src/components/PrimaryNav/PrimaryNav.test.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
+import * as versionsAPI from "@canonical/jujulib/dist/api/versions";
 
 import { configFactory, generalStateFactory } from "testing/factories/general";
 import {
@@ -17,6 +18,10 @@ import PrimaryNav from "./PrimaryNav";
 
 const mockStore = configureStore([]);
 describe("Primary Nav", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("applies is-selected state correctly", () => {
     const store = mockStore(rootStateFactory.withGeneralConfig().build());
     render(
@@ -167,6 +172,7 @@ describe("Primary Nav", () => {
   });
 
   it("shows an update available message if there is an update available for the dashboard", async () => {
+    jest.spyOn(versionsAPI, "dashboardUpdateAvailable").mockResolvedValue(true);
     const store = mockStore(
       rootStateFactory
         .withGeneralConfig()
@@ -185,7 +191,11 @@ describe("Primary Nav", () => {
     );
     expect(notification).toBeInTheDocument();
   });
+
   it("doesn't show an update available message if there is no update available for the dashboard", async () => {
+    jest
+      .spyOn(versionsAPI, "dashboardUpdateAvailable")
+      .mockResolvedValue(false);
     const store = mockStore(
       rootStateFactory
         .withGeneralConfig()

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -3,7 +3,7 @@ import { Icon, StatusLabel, Tooltip } from "@canonical/react-components";
 import classNames from "classnames";
 import Logo from "components/Logo/Logo";
 import UserMenu from "components/UserMenu/UserMenu";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { NavLink } from "react-router-dom";
 import { getAppVersion } from "store/general/selectors";
@@ -73,10 +73,18 @@ const ControllersLink = () => {
 const PrimaryNav = () => {
   const appVersion = useSelector(getAppVersion);
   const [updateAvailable, setUpdateAvailable] = useState(false);
+  const [versionRequested, setVersionRequested] = useState(false);
 
-  dashboardUpdateAvailable(appVersion || "").then((e) => {
-    setUpdateAvailable(e);
-  });
+  useEffect(() => {
+    // Prevent multiple request calls while the version request is in progress
+    // or completed.
+    if (!versionRequested) {
+      setVersionRequested(true);
+      dashboardUpdateAvailable(appVersion || "").then((e) => {
+        setUpdateAvailable(e);
+      });
+    }
+  }, [appVersion, versionRequested]);
 
   return (
     <nav className="p-primary-nav">

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -70,21 +70,21 @@ const ControllersLink = () => {
   );
 };
 
+let didInit = false;
 const PrimaryNav = () => {
   const appVersion = useSelector(getAppVersion);
   const [updateAvailable, setUpdateAvailable] = useState(false);
-  const [versionRequested, setVersionRequested] = useState(false);
 
   useEffect(() => {
-    // Prevent multiple request calls while the version request is in progress
-    // or completed.
-    if (!versionRequested) {
-      setVersionRequested(true);
-      dashboardUpdateAvailable(appVersion || "").then((e) => {
-        setUpdateAvailable(e);
-      });
-    }
-  }, [appVersion, versionRequested]);
+    if (didInit || !appVersion) return;
+    didInit = true;
+    dashboardUpdateAvailable(appVersion || "").then((e) => {
+      setUpdateAvailable(e);
+    });
+    return () => {
+      didInit = false;
+    };
+  }, [appVersion]);
 
   return (
     <nav className="p-primary-nav">


### PR DESCRIPTION
## Done

- Fix lockup caused by API call on each render.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Load the dashboard.
- Make sure that you can interact with the dashboard and that it doesn't lock up almost immediately.

## Details

https://warthogs.atlassian.net/browse/WD-2663

