### PR TITLE
WD-2669 - Fix breadcrumbs width

### DIFF
--- a/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumb/Breadcrumb.tsx
@@ -1,16 +1,22 @@
-import { Link, useParams } from "react-router-dom";
+import { Link } from "react-router-dom";
 
-import type { EntityDetailsRoute } from "components/Routes/Routes";
+import { useEntityDetailsParams } from "components/hooks";
 
 import "./_breadcrumbs.scss";
 
 export default function Breadcrumb(): JSX.Element {
-  const { userName, modelName, appName, unitId, machineId } =
-    useParams<EntityDetailsRoute>();
+  const {
+    userName,
+    modelName,
+    appName,
+    unitId,
+    machineId,
+    isNestedEntityPage,
+  } = useEntityDetailsParams();
 
   const generateBreadcrumbs = function (): JSX.Element {
     const view = machineId ? "machines" : "apps";
-    const isNestedEntityPage = !!appName || !!unitId || !!machineId;
+
     if (isNestedEntityPage) {
       return (
         <>

--- a/src/components/hooks.test.tsx
+++ b/src/components/hooks.test.tsx
@@ -1,0 +1,86 @@
+import { renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { Route, Routes, MemoryRouter } from "react-router-dom";
+import { QueryParamProvider } from "use-query-params";
+import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
+import { rootStateFactory } from "testing/factories";
+import configureStore from "redux-mock-store";
+
+import { useEntityDetailsParams } from "./hooks";
+
+const mockStore = configureStore([]);
+
+describe("useEntityDetailsParams", () => {
+  it("retrieve entity details from the URL", () => {
+    const { result } = renderHook(() => useEntityDetailsParams(), {
+      wrapper: ({ children }) => (
+        <Provider store={mockStore(rootStateFactory.build())}>
+          <MemoryRouter
+            initialEntries={["/models/eggman@external/group-test/machine/0"]}
+          >
+            <QueryParamProvider adapter={ReactRouter6Adapter}>
+              <Routes>
+                <Route
+                  path="/models/:userName/:modelName/machine/:machineId"
+                  element={children}
+                />
+              </Routes>
+            </QueryParamProvider>
+          </MemoryRouter>
+        </Provider>
+      ),
+    });
+    expect(result.current).toStrictEqual({
+      appName: undefined,
+      isNestedEntityPage: true,
+      machineId: "0",
+      modelName: "group-test",
+      unitId: undefined,
+      userName: "eggman@external",
+    });
+  });
+
+  it("handles non nested pages", () => {
+    const { result } = renderHook(() => useEntityDetailsParams(), {
+      wrapper: ({ children }) => (
+        <Provider store={mockStore(rootStateFactory.build())}>
+          <MemoryRouter
+            initialEntries={["/models/eggman@external/group-test/applications"]}
+          >
+            <QueryParamProvider adapter={ReactRouter6Adapter}>
+              <Routes>
+                <Route
+                  path="/models/:userName/:modelName/applications"
+                  element={children}
+                />
+              </Routes>
+            </QueryParamProvider>
+          </MemoryRouter>
+        </Provider>
+      ),
+    });
+    expect(result.current.isNestedEntityPage).toBe(false);
+  });
+
+  it("handles nested pages", () => {
+    const { result } = renderHook(() => useEntityDetailsParams(), {
+      wrapper: ({ children }) => (
+        <Provider store={mockStore(rootStateFactory.build())}>
+          <MemoryRouter
+            initialEntries={["/models/eggman@external/group-test/app/etcd"]}
+          >
+            <QueryParamProvider adapter={ReactRouter6Adapter}>
+              <Routes>
+                <Route
+                  path="/models/:userName/:modelName/app/:appName"
+                  element={children}
+                />
+              </Routes>
+            </QueryParamProvider>
+          </MemoryRouter>
+        </Provider>
+      ),
+    });
+    expect(result.current.isNestedEntityPage).toBe(true);
+  });
+});

--- a/src/components/hooks.ts
+++ b/src/components/hooks.ts
@@ -1,0 +1,15 @@
+import { useParams } from "react-router-dom";
+import { EntityDetailsRoute } from "components/Routes/Routes";
+
+export const useEntityDetailsParams = () => {
+  const { userName, modelName, appName, unitId, machineId } =
+    useParams<EntityDetailsRoute>();
+  return {
+    appName,
+    isNestedEntityPage: !!appName || !!unitId || !!machineId,
+    machineId,
+    modelName,
+    unitId,
+    userName,
+  };
+};

--- a/src/pages/EntityDetails/EntityDetails.test.tsx
+++ b/src/pages/EntityDetails/EntityDetails.test.tsx
@@ -46,17 +46,24 @@ describe("Entity Details Container", () => {
   function renderComponent({
     props,
     storeState = state,
-  }: { props?: Props; storeState?: RootState } = {}) {
+    path = "/models/kirk@external/enterprise",
+    urlPattern = "/models/:userName/:modelName",
+  }: {
+    props?: Props;
+    storeState?: RootState;
+    path?: string;
+    urlPattern?: string;
+  } = {}) {
     const store = mockStore(storeState);
 
-    window.history.pushState({}, "", "/models/kirk@external/enterprise");
+    window.history.pushState({}, "", path);
     render(
       <Provider store={store}>
         <BrowserRouter>
           <QueryParamProvider adapter={ReactRouter6Adapter}>
             <Routes>
               <Route
-                path="/models/:userName/:modelName"
+                path={urlPattern}
                 element={
                   <EntityDetails
                     type={props?.type}
@@ -257,6 +264,18 @@ describe("Entity Details Container", () => {
     await waitFor(() => {
       expect(document.querySelector(".l-content")).toHaveClass(
         "l-content--has-webcli"
+      );
+    });
+  });
+
+  it("gives the header a class when the header shouldbe a single column", async () => {
+    renderComponent({
+      path: "/models/eggman@external/group-test/app/etcd",
+      urlPattern: "/models/:userName/:modelName/app/:appName",
+    });
+    await waitFor(() => {
+      expect(document.querySelector(".entity-details__header")).toHaveClass(
+        "entity-details__header--single-col"
       );
     });
   });

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -29,6 +29,7 @@ import { useAppSelector } from "store/store";
 import useWindowTitle from "hooks/useWindowTitle";
 
 import FadeIn from "animations/FadeIn";
+import { useEntityDetailsParams } from "components/hooks";
 
 import "./_entity-details.scss";
 
@@ -61,6 +62,7 @@ const EntityDetails = ({
   const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
   const modelInfo = useSelector(getModelInfo(modelUUID));
   const applications = useSelector(getModelApplications(modelUUID));
+  const { isNestedEntityPage } = useEntityDetailsParams();
 
   const [query, setQuery] = useQueryParams({
     panel: StringParam,
@@ -238,7 +240,11 @@ const EntityDetails = ({
   return (
     <BaseLayout>
       <Header>
-        <div className="entity-details__header">
+        <div
+          className={classNames("entity-details__header", {
+            "entity-details__header--single-col": isNestedEntityPage,
+          })}
+        >
           <Breadcrumb />
           <div
             className="entity-details__view-selector"

--- a/src/pages/EntityDetails/_entity-details.scss
+++ b/src/pages/EntityDetails/_entity-details.scss
@@ -2,6 +2,7 @@
 @import "vanilla-framework/scss/vanilla";
 @import "../../scss/breakpoints";
 @import "../../scss/custom/icons";
+@import "../../scss/variables";
 @include vf-b-placeholders;
 
 @mixin entity-details-layout {
@@ -96,7 +97,6 @@
       align-items: center;
       display: grid;
       gap: 2rem;
-      grid-template-columns: 1fr;
       grid-template-columns: repeat(3, 1fr);
       padding-top: 0;
     }
@@ -109,6 +109,22 @@
 
       .p-breadcrumbs__item:not(:first-of-type) {
         text-indent: 1.25rem;
+      }
+    }
+
+    &.entity-details__header--single-col {
+      gap: 0;
+      grid-template-columns: 1fr;
+      min-height: $top-header-height;
+
+      @include desktop {
+        grid-template-columns: 1fr;
+      }
+
+      .p-breadcrumbs {
+        // Centre the content to match the tabs.
+        margin-bottom: 1.25rem;
+        margin-top: 1.25rem;
       }
     }
 


### PR DESCRIPTION
## Done

- Give the breadcrumbs the full width of the header.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to an app, unit or machine details page and the breadcrumb should not be squashed to the left.

## Details

https://warthogs.atlassian.net/browse/WD-2669
Fixes: #1419.

## Screenshots

<img width="927" alt="Screenshot 2023-03-16 at 2 09 53 pm" src="https://user-images.githubusercontent.com/361637/225510471-a1092ec9-b226-4951-8605-1545515e4809.png">

