### PR TITLE
WD-2757- WebCLI history

### DIFF
--- a/src/components/WebCLI/WebCLI.test.tsx
+++ b/src/components/WebCLI/WebCLI.test.tsx
@@ -46,6 +46,7 @@ describe("WebCLI", () => {
     // Reset the console.error to the original console.error in case
     // it was cobbered in a test.
     console.error = originalError;
+    localStorage.clear();
   });
 
   /*
@@ -134,6 +135,54 @@ describe("WebCLI", () => {
         resolve();
       });
     });
+  });
+
+  it("navigate back through the history", async () => {
+    localStorage.setItem(
+      "cliHistory",
+      JSON.stringify(["status", "help", "whoami"])
+    );
+    await generateComponent();
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "{arrowup}{arrowup}");
+    expect(input).toHaveValue("help");
+  });
+
+  it("navigate forward through the history", async () => {
+    localStorage.setItem(
+      "cliHistory",
+      JSON.stringify(["status", "help", "whoami"])
+    );
+    await generateComponent();
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "{arrowup}{arrowup}{arrowup}");
+    expect(input).toHaveValue("status");
+    await userEvent.type(input, "{arrowdown}{arrowdown}");
+    expect(input).toHaveValue("whoami");
+  });
+
+  it("can navigate forward to the empty state", async () => {
+    localStorage.setItem(
+      "cliHistory",
+      JSON.stringify(["status", "help", "whoami"])
+    );
+    await generateComponent();
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "{arrowup}{arrowup}");
+    expect(input).toHaveValue("help");
+    await userEvent.type(input, "{arrowdown}{arrowdown}");
+    expect(input).toHaveValue("");
+  });
+
+  it("prevents navigating past the last history item", async () => {
+    localStorage.setItem(
+      "cliHistory",
+      JSON.stringify(["status", "help", "whoami"])
+    );
+    await generateComponent();
+    const input = screen.getByRole("textbox");
+    await userEvent.type(input, "{arrowup}{arrowup}{arrowup}{arrowup}");
+    expect(input).toHaveValue("status");
   });
 
   it("supports macaroon based authentication", async () => {

--- a/src/components/WebCLI/WebCLI.tsx
+++ b/src/components/WebCLI/WebCLI.tsx
@@ -60,7 +60,7 @@ const WebCLI = ({
     wsMessageStore.current = "";
     setOutput(""); // Clear the output when sending a new message.
   };
-  const keyListener = useCallback(
+  const keydownListener = useCallback(
     (event: KeyboardEvent) => {
       if (event.key === "ArrowUp" || event.key === "ArrowDown") {
         let newPosition = historyPosition;
@@ -85,13 +85,25 @@ const WebCLI = ({
     [cliHistory, historyPosition]
   );
 
+  const keyupListener = useCallback((event: KeyboardEvent) => {
+    if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+      if (inputRef.current) {
+        const position = inputRef.current.value.length;
+        // Move the cursor to the end of the history value that was just inserted.
+        inputRef.current.setSelectionRange(position, position);
+      }
+    }
+  }, []);
+
   useEffect(() => {
     const input = inputRef.current;
-    input?.addEventListener("keydown", keyListener);
+    input?.addEventListener("keydown", keydownListener);
+    input?.addEventListener("keyup", keyupListener);
     return () => {
-      input?.removeEventListener("keydown", keyListener);
+      input?.removeEventListener("keydown", keydownListener);
+      input?.removeEventListener("keyup", keyupListener);
     };
-  }, [keyListener]);
+  }, [keydownListener, keyupListener]);
 
   const wsAddress = useMemo(() => {
     if (!controllerWSHost || !modelUUID) {

--- a/src/components/WebCLI/WebCLI.tsx
+++ b/src/components/WebCLI/WebCLI.tsx
@@ -35,6 +35,8 @@ type Authentication = {
   macaroons?: Macaroon[];
 };
 
+export const MAX_HISTORY = 200;
+
 const WebCLI = ({
   controllerWSHost,
   credentials,
@@ -154,7 +156,11 @@ const WebCLI = ({
     const formFields = e.currentTarget.children;
     if ("command" in formFields) {
       command = (formFields.command as HTMLInputElement).value.trim();
-      setCLIHistory(cliHistory.concat([command]));
+      let history = cliHistory.concat([command]);
+      if (history.length > MAX_HISTORY) {
+        history = history.slice(-MAX_HISTORY);
+      }
+      setCLIHistory(history);
       // Reset the position in case the user was navigating through the history.
       setHistoryPosition(0);
     }


### PR DESCRIPTION
## Done

- Add history to the WebCLI.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Using a local controller go to a model details page.
- Using the CLI at the bottom enter a few commands.
- Press the up and down arrows and you should be able to navigate through your history.
- Refresh the page and you should still be able to navigate through your history.

## Details

https://warthogs.atlassian.net/browse/WD-2757
Fixes: #724.

## Screenshots

![Screen Recording 2023-03-21 at 12 36 22 pm](https://user-images.githubusercontent.com/361637/226499935-1637115b-37e8-4e7e-bd71-4c1f844e336a.gif)

