### PR TITLE
WD-2759 - Fix the size of the topology on mobile

### DIFF
--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -30,8 +30,13 @@
     .p-icon--fullscreen {
       bottom: 10px;
       cursor: pointer;
+      display: none;
       position: absolute;
       right: 10px;
+
+      @include medium {
+        display: inline-block;
+      }
     }
   }
 


### PR DESCRIPTION
## Done

- Fix the size of the topology on mobile.
- Disable the full width button (it's already full width).

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to a model details page.
- Resize your window down just until the model image goes full width.
- Click the 'Model access' button and then close the panel (this creates a state update).
- The icons should be the same size as before (it used to make them all tiny).
- Check that there is no full screen button (kind of a "[ ]" icon in the bottom left of the image).

## Details

https://warthogs.atlassian.net/browse/WD-2759
Fixes: #858.
Fixes: #859.
