### PR TITLE
WD-2807 - Handle 2.9 configuration

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -88,6 +88,12 @@ function bootstrap() {
   if (!config) {
     error = "No configuration found.";
   }
+  // Support Juju 2.9 deployments with the old configuration values.
+  // XXX This can be removed once we drop support for 2.9 with the 3.0 release.
+  if (config?.baseControllerURL === null) {
+    const protocol = window.location.protocol.includes("https") ? "wss" : "ws";
+    config.controllerAPIEndpoint = `${protocol}://${window.location.host}/api`;
+  }
   const controllerEndpointError = getControllerAPIEndpointErrors(
     config?.controllerAPIEndpoint
   );
@@ -116,12 +122,6 @@ function bootstrap() {
         : "ws";
       config.controllerAPIEndpoint = `${protocol}://${window.location.host}${controllerAPIEndpoint}`;
     }
-  }
-  // Support Juju 2.9 deployments with the old configuration values.
-  // XXX This can be removed once we drop support for 2.9 with the 3.0 release.
-  if (config.baseControllerURL === null) {
-    const protocol = window.location.protocol.includes("https") ? "wss" : "ws";
-    config.controllerAPIEndpoint = `${protocol}://${window.location.host}/api`;
   }
 
   if (process.env.NODE_ENV === "production") {


### PR DESCRIPTION
## Done

- Handle config validation for Juju 2.9.

## QA

- Generate a tarball `yarn generate-release-tarball`.
- Set up a Juju 2.9 controller.
- Move the tarball somewhere the controller can access.
- From the controller upgrade the dashboard `juju upgrade-dashboard path/to/juju-dashboard-0.10.0.tar.bz2`.
- Load the dashboard in your browser.
- The dashboard should not display a configuration error.

## Details

https://warthogs.atlassian.net/browse/WD-2807

