### PR TITLE
WD-2808 - Prevent unnecessary topology rerenders

### DIFF
--- a/src/components/Topology/Topology.tsx
+++ b/src/components/Topology/Topology.tsx
@@ -1,6 +1,5 @@
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, memo } from "react";
 import * as d3 from "d3";
-import cloneDeep from "clone-deep";
 
 import defaultCharmIcon from "static/images/icons/default-charm-icon.svg";
 import { generateIconPath } from "store/juju/utils/models";
@@ -141,206 +140,216 @@ const getRelationPosition = (data: string[]) => {
   };
 };
 
-const Topology = ({
-  annotations,
-  applications: applicationData,
-  relations: relationData,
-  width,
-  height,
-}: Props) => {
-  const ref = useRef<SVGSVGElement>(null);
+// Memoize the component as the D3 rendering is expensive and causes visual
+// glitches.
+const Topology = memo(
+  ({
+    annotations: annotationData,
+    applications: applicationData,
+    relations: relationData,
+    width,
+    height,
+  }: Props) => {
+    const ref = useRef<SVGSVGElement>(null);
 
-  const annotationData = cloneDeep(annotations) ?? {};
+    const { deltaX, deltaY } = computePositionDelta(annotationData);
 
-  const { deltaX, deltaY } = computePositionDelta(annotationData);
-
-  const applications: Application[] = Object.entries(applicationData ?? {}).map(
-    ([appName, application]) => {
+    const applications: Application[] = Object.entries(
+      applicationData ?? {}
+    ).map(([appName, application]) => {
       return {
         ...application,
-        annotations: annotationData[appName] ?? {},
+        annotations: annotationData?.[appName] ?? {},
         name: appName,
       };
-    }
-  );
+    });
 
-  // Apply deltas to the annotations.
-  for (const appName in annotationData) {
-    const annotation = annotationData[appName];
-    if (annotation["gui-x"]) {
-      annotation["gui-x"] = applyDelta(annotation["gui-x"], deltaX).toString();
-    }
-    if (annotation["gui-y"]) {
-      annotation["gui-y"] = applyDelta(annotation["gui-y"], deltaY).toString();
-    }
-  }
-
-  let { maxX, maxY } = computeMaxXY(annotationData);
-  if (maxX === 0) {
-    // If there is no maxX then all of the icons are unplaced
-    // so set a maximum width.
-    maxX = 500;
-  }
-
-  // Dedupe the relations as we only draw a single line between two
-  // applications regardless of how many relations are between them.
-  const extractor = /(.+):(.+)\s(.+):(.+)/;
-  const endpoints = Object.entries(relationData || {}).reduce<string[]>(
-    (acc, [key, relation]) => {
-      // We don't draw peer relations so we can ignore them.
-      if (relation.endpoints.length > 1) {
-        const parts = key.match(extractor);
-        if (parts) {
-          acc.push(`${parts[1]}:${parts[3]}`);
-        }
+    // Apply deltas to the annotations.
+    for (const appName in annotationData) {
+      const annotation = annotationData[appName];
+      if (annotation["gui-x"]) {
+        annotation["gui-x"] = applyDelta(
+          annotation["gui-x"],
+          deltaX
+        ).toString();
       }
-      return acc;
-    },
-    []
-  );
-
-  // Remove any duplicate endpoints and split into pairs.
-  const deDupedRelations = [...new Set(endpoints)].map((pair) =>
-    pair.split(":")
-  );
-  // Remove relations that do not have all applications in the map.
-  // The missing application is likely a cross-model-relation which isn't
-  // fully supported yet.
-  // https://github.com/canonical-web-and-design/jaas-dashboard/issues/526
-  const applicationNames = Object.keys(applicationData ?? {});
-
-  const relations = deDupedRelations.filter(
-    (relation) =>
-      applicationNames.includes(relation[0]) &&
-      applicationNames.includes(relation[1])
-  );
-
-  useEffect(() => {
-    const svgNode = ref.current;
-    if (!svgNode) {
-      return;
+      if (annotation["gui-y"]) {
+        annotation["gui-y"] = applyDelta(
+          annotation["gui-y"],
+          deltaY
+        ).toString();
+      }
     }
-    const topo = d3
-      .select(svgNode)
-      .attr("viewBox", `0 0 ${width} ${height}`)
-      .append("g");
 
-    const appIcons = topo.selectAll(".application").data(applications);
+    let { maxX, maxY } = computeMaxXY(annotationData);
+    if (maxX === 0) {
+      // If there is no maxX then all of the icons are unplaced
+      // so set a maximum width.
+      maxX = 500;
+    }
 
-    let gridCount = {
-      x: 0,
-      y: maxY,
-    };
-
-    const appIcon = appIcons
-      .enter()
-      .append("g")
-      .attr("transform", (d) => {
-        const x =
-          d.annotations["gui-x"] !== undefined
-            ? d.annotations["gui-x"]
-            : gridCount.x;
-        const y =
-          d.annotations["gui-y"] !== undefined
-            ? d.annotations["gui-y"]
-            : gridCount.y;
-        gridCount.x += 250;
-        // Let the placed units determine the max width of the visualization.
-        // and move the grid units to a new line.
-        if (gridCount.x > maxX) {
-          gridCount.x = 0;
-          gridCount.y += 200;
+    // Dedupe the relations as we only draw a single line between two
+    // applications regardless of how many relations are between them.
+    const extractor = /(.+):(.+)\s(.+):(.+)/;
+    const endpoints = Object.entries(relationData || {}).reduce<string[]>(
+      (acc, [key, relation]) => {
+        // We don't draw peer relations so we can ignore them.
+        if (relation.endpoints.length > 1) {
+          const parts = key.match(extractor);
+          if (parts) {
+            acc.push(`${parts[1]}:${parts[3]}`);
+          }
         }
-        return `translate(${x}, ${y})`;
-      });
+        return acc;
+      },
+      []
+    );
 
-    appIcon
-      .classed("application", true)
-      .attr("data-name", (d) => d.name)
-      .append("circle")
-      .attr("cx", (d) => (isSubordinate(d) ? 60 : 90))
-      .attr("cy", (d) => (isSubordinate(d) ? 60 : 90))
-      .attr("r", (d) => (isSubordinate(d) ? 60 : 90))
-      .attr("fill", "#f5f5f5")
-      .attr("stroke-width", 3)
-      .attr("stroke", "#888888")
-      .call((_) => {
-        // When ever a new element is added zoom the canvas to fit.
-        let svgHeight = 0;
-        let svgWidth = 0;
-        let parentHeight = 0;
-        let parentWidth = 0;
-        const rect = topo?.node()?.getBoundingClientRect();
-        // Get the rect of the containing <svg>. This could be different to the
-        // width and height passed into this component due to the responsive design.
-        const parentRect = topo.node()?.parentElement?.getBoundingClientRect();
-        if (rect && parentRect) {
-          svgWidth = rect.width;
-          svgHeight = rect.height;
-          parentWidth = parentRect.width;
-          parentHeight = parentRect.height;
-        }
-        if (svgWidth > 0 && svgHeight > 0) {
-          const containerScale = Math.min(
-            width / parentWidth,
-            height / parentHeight
-          );
-          // Magic number that presents reasonable padding around the viz.
-          const padding = 200 / containerScale;
-          const scale = Math.min(
-            parentWidth / (svgWidth + padding),
-            parentHeight / (svgHeight + padding)
-          );
-          const translateX =
-            ((parentWidth - svgWidth * scale) / 2) * containerScale;
-          const translateY =
-            ((parentHeight - svgHeight * scale) / 2) * containerScale;
-          topo.attr(
-            "transform",
-            `translate(${translateX},${translateY}) scale(${scale},${scale})`
-          );
-        }
-      });
+    // Remove any duplicate endpoints and split into pairs.
+    const deDupedRelations = [...new Set(endpoints)].map((pair) =>
+      pair.split(":")
+    );
+    // Remove relations that do not have all applications in the map.
+    // The missing application is likely a cross-model-relation which isn't
+    // fully supported yet.
+    // https://github.com/canonical-web-and-design/jaas-dashboard/issues/526
+    const applicationNames = Object.keys(applicationData ?? {});
 
-    appIcon
-      .append("image")
-      .attr("xlink:href", (d) => generateIconPath(d["charm-url"]))
-      // use a fallback image if the icon is not found
-      .on("error", function () {
-        d3.select(this).attr("xlink:href", () => defaultCharmIcon);
-      })
-      .attr("width", (d) => (isSubordinate(d) ? 96 : 126))
-      .attr("height", (d) => (isSubordinate(d) ? 96 : 126))
-      .attr("transform", (d) =>
-        isSubordinate(d) ? "translate(13, 13)" : "translate(28, 28)"
-      )
-      .attr("clip-path", (d) =>
-        isSubordinate(d)
-          ? "circle(43px at 48px 48px)"
-          : "circle(55px at 63px 63px)"
-      );
+    const relations = deDupedRelations.filter(
+      (relation) =>
+        applicationNames.includes(relation[0]) &&
+        applicationNames.includes(relation[1])
+    );
 
-    const relationLines = topo.selectAll(".relation").data(relations);
-    const relationLine = relationLines.enter().insert("g", ":first-child");
+    useEffect(() => {
+      const svgNode = ref.current;
+      if (!svgNode) {
+        return;
+      }
+      const topo = d3
+        .select(svgNode)
+        .attr("viewBox", `0 0 ${width} ${height}`)
+        .append("g");
 
-    relationLine
-      .classed("relation", true)
-      .append("line")
-      .attr("x1", (d) => getRelationPosition(d).x1)
-      .attr("y1", (d) => getRelationPosition(d).y1)
-      .attr("x2", (d) => getRelationPosition(d).x2)
-      .attr("y2", (d) => getRelationPosition(d).y2)
-      .attr("stroke", "#666666")
-      .attr("stroke-width", 2);
+      const appIcons = topo.selectAll(".application").data(applications);
 
-    appIcons.exit().remove();
-    relationLines.exit().remove();
+      let gridCount = {
+        x: 0,
+        y: maxY,
+      };
 
-    return () => {
-      topo.remove();
-    };
-  }, [applications, deltaX, deltaY, height, width, maxX, maxY, relations]);
-  return <svg ref={ref} />;
-};
+      const appIcon = appIcons
+        .enter()
+        .append("g")
+        .attr("transform", (d) => {
+          const x =
+            d.annotations["gui-x"] !== undefined
+              ? d.annotations["gui-x"]
+              : gridCount.x;
+          const y =
+            d.annotations["gui-y"] !== undefined
+              ? d.annotations["gui-y"]
+              : gridCount.y;
+          gridCount.x += 250;
+          // Let the placed units determine the max width of the visualization.
+          // and move the grid units to a new line.
+          if (gridCount.x > maxX) {
+            gridCount.x = 0;
+            gridCount.y += 200;
+          }
+          return `translate(${x}, ${y})`;
+        });
+
+      appIcon
+        .classed("application", true)
+        .attr("data-name", (d) => d.name)
+        .append("circle")
+        .attr("cx", (d) => (isSubordinate(d) ? 60 : 90))
+        .attr("cy", (d) => (isSubordinate(d) ? 60 : 90))
+        .attr("r", (d) => (isSubordinate(d) ? 60 : 90))
+        .attr("fill", "#f5f5f5")
+        .attr("stroke-width", 3)
+        .attr("stroke", "#888888")
+        .call((_) => {
+          // When ever a new element is added zoom the canvas to fit.
+          let svgHeight = 0;
+          let svgWidth = 0;
+          let parentHeight = 0;
+          let parentWidth = 0;
+          const rect = topo?.node()?.getBoundingClientRect();
+          // Get the rect of the containing <svg>. This could be different to the
+          // width and height passed into this component due to the responsive design.
+          const parentRect = topo
+            .node()
+            ?.parentElement?.getBoundingClientRect();
+          if (rect && parentRect) {
+            svgWidth = rect.width;
+            svgHeight = rect.height;
+            parentWidth = parentRect.width;
+            parentHeight = parentRect.height;
+          }
+          if (svgWidth > 0 && svgHeight > 0) {
+            const containerScale = Math.min(
+              width / parentWidth,
+              height / parentHeight
+            );
+            // Magic number that presents reasonable padding around the viz.
+            const padding = 200 / containerScale;
+            const scale = Math.min(
+              parentWidth / (svgWidth + padding),
+              parentHeight / (svgHeight + padding)
+            );
+            const translateX =
+              ((parentWidth - svgWidth * scale) / 2) * containerScale;
+            const translateY =
+              ((parentHeight - svgHeight * scale) / 2) * containerScale;
+            topo.attr(
+              "transform",
+              `translate(${translateX},${translateY}) scale(${scale},${scale})`
+            );
+          }
+        });
+
+      appIcon
+        .append("image")
+        .attr("xlink:href", (d) => generateIconPath(d["charm-url"]))
+        // use a fallback image if the icon is not found
+        .on("error", function () {
+          d3.select(this).attr("xlink:href", () => defaultCharmIcon);
+        })
+        .attr("width", (d) => (isSubordinate(d) ? 96 : 126))
+        .attr("height", (d) => (isSubordinate(d) ? 96 : 126))
+        .attr("transform", (d) =>
+          isSubordinate(d) ? "translate(13, 13)" : "translate(28, 28)"
+        )
+        .attr("clip-path", (d) =>
+          isSubordinate(d)
+            ? "circle(43px at 48px 48px)"
+            : "circle(55px at 63px 63px)"
+        );
+
+      const relationLines = topo.selectAll(".relation").data(relations);
+      const relationLine = relationLines.enter().insert("g", ":first-child");
+
+      relationLine
+        .classed("relation", true)
+        .append("line")
+        .attr("x1", (d) => getRelationPosition(d).x1)
+        .attr("y1", (d) => getRelationPosition(d).y1)
+        .attr("x2", (d) => getRelationPosition(d).x2)
+        .attr("y2", (d) => getRelationPosition(d).y2)
+        .attr("stroke", "#666666")
+        .attr("stroke-width", 2);
+
+      appIcons.exit().remove();
+      relationLines.exit().remove();
+
+      return () => {
+        topo.remove();
+      };
+    }, [applications, deltaX, deltaY, height, width, maxX, maxY, relations]);
+    return <svg ref={ref} />;
+  }
+);
 
 export default Topology;


### PR DESCRIPTION
## Done

- Prevent unnecessary topology rerenders.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Using chrome go to a model details page.
- Click on the header tabs and check that each tab change doesn't result in the topology being rerendered (it used to very obviously redraw the icons).

## Details

Fixes: #430.
https://warthogs.atlassian.net/browse/WD-2808
