### PR TITLE
WD-2831 - Refactor EntityDetails

### DIFF
--- a/src/pages/EntityDetails/App/App.tsx
+++ b/src/pages/EntityDetails/App/App.tsx
@@ -17,8 +17,6 @@ import EntityInfo from "components/EntityInfo/EntityInfo";
 import FormikFormData from "components/FormikFormData/FormikFormData";
 import InfoPanel from "components/InfoPanel/InfoPanel";
 
-import EntityDetails from "pages/EntityDetails/EntityDetails";
-
 import useTableRowClick from "hooks/useTableRowClick";
 
 import { extractRevisionNumber } from "store/juju/utils/models";
@@ -264,7 +262,7 @@ export default function App(): JSX.Element {
   };
 
   return (
-    <EntityDetails type="app">
+    <>
       <div>
         <InfoPanel />
         <>
@@ -350,6 +348,6 @@ export default function App(): JSX.Element {
           )}
         </div>
       </div>
-    </EntityDetails>
+    </>
   );
 }

--- a/src/pages/EntityDetails/EntityDetails.test.tsx
+++ b/src/pages/EntityDetails/EntityDetails.test.tsx
@@ -62,17 +62,9 @@ describe("Entity Details Container", () => {
         <BrowserRouter>
           <QueryParamProvider adapter={ReactRouter6Adapter}>
             <Routes>
-              <Route
-                path={urlPattern}
-                element={
-                  <EntityDetails
-                    type={props?.type}
-                    onApplicationsFilter={props?.onApplicationsFilter}
-                  >
-                    {props?.children}
-                  </EntityDetails>
-                }
-              />
+              <Route path={urlPattern} element={<EntityDetails />}>
+                {props?.children}
+              </Route>
             </Routes>
           </QueryParamProvider>
         </BrowserRouter>
@@ -208,7 +200,9 @@ describe("Entity Details Container", () => {
 
   it("shows the supplied child", () => {
     const children = "Hello I am a child!";
-    renderComponent({ props: { children } });
+    renderComponent({
+      props: { children: <Route path="" element={children} /> },
+    });
     expect(screen.getByText(children)).toBeInTheDocument();
   });
 
@@ -277,6 +271,40 @@ describe("Entity Details Container", () => {
       expect(document.querySelector(".entity-details__header")).toHaveClass(
         "entity-details__header--single-col"
       );
+    });
+  });
+
+  it("shows the search & filter box in the apps tab", async () => {
+    renderComponent({
+      path: "/models/eggman@external/group-test",
+      urlPattern: "/models/:userName/:modelName",
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("filter-applications")).toBeInTheDocument();
+    });
+  });
+
+  it("does not the search & filter box for subsections", async () => {
+    renderComponent({
+      path: "/models/eggman@external/group-test/app/etcd",
+      urlPattern: "/models/:userName/:modelName/app/:appName",
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("filter-applications")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not the search & filter box for non-apps tabs", async () => {
+    renderComponent({
+      path: "/models/eggman@external/group-test?activeView=integrations",
+      urlPattern: "/models/:userName/:modelName",
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("filter-applications")
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/src/pages/EntityDetails/Machine/Machine.tsx
+++ b/src/pages/EntityDetails/Machine/Machine.tsx
@@ -23,8 +23,6 @@ import {
   unitTableHeaders,
 } from "tables/tableHeaders";
 
-import EntityDetails from "pages/EntityDetails/EntityDetails";
-
 import EntityInfo from "components/EntityInfo/EntityInfo";
 import InfoPanel from "components/InfoPanel/InfoPanel";
 
@@ -99,7 +97,7 @@ export default function Machine() {
   };
 
   return (
-    <EntityDetails type="machine">
+    <>
       <div>
         <InfoPanel />
         <EntityInfo data={MachineEntityData} />
@@ -124,6 +122,6 @@ export default function Machine() {
           </div>
         </div>
       </div>
-    </EntityDetails>
+    </>
   );
 }

--- a/src/pages/EntityDetails/Model/Model.test.tsx
+++ b/src/pages/EntityDetails/Model/Model.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -146,7 +145,7 @@ describe("Model", () => {
     ).toBeInTheDocument();
   });
 
-  it("view toggles hide and show tables", async () => {
+  it("displays the apps table by default", async () => {
     state.juju.modelWatcherData = {
       abc123: modelWatcherModelDataFactory.build({
         applications: {
@@ -178,23 +177,216 @@ describe("Model", () => {
     expect(
       document.querySelector(".entity-details__main > .entity-details__apps")
     ).toBeInTheDocument();
-    await userEvent.click(screen.getByTestId("tab-link-Machines"));
+    expect(
+      document.querySelector(
+        ".entity-details__main > .entity-details__machines"
+      )
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelector(
+        ".entity-details__main > .entity-details__relations"
+      )
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelector(".entity-details__action-logs")
+    ).not.toBeInTheDocument();
+  });
+
+  it("can display the apps table", async () => {
+    state.juju.modelWatcherData = {
+      abc123: modelWatcherModelDataFactory.build({
+        applications: {
+          "ceph-mon": applicationInfoFactory.build(),
+        },
+        machines: {
+          "0": machineChangeDeltaFactory.build(),
+        },
+        relations: {
+          "wordpress:db mysql:db": relationChangeDeltaFactory.build(),
+        },
+      }),
+    };
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={["/models/eggman@external/test1?activeView=apps"]}
+        >
+          <QueryParamProvider adapter={ReactRouter6Adapter}>
+            <Routes>
+              <Route path="/models/:userName/:modelName" element={<Model />} />
+            </Routes>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    Element.prototype.scrollIntoView = jest.fn();
+
+    expect(
+      document.querySelector(".entity-details__main > .entity-details__apps")
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector(
+        ".entity-details__main > .entity-details__machines"
+      )
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelector(
+        ".entity-details__main > .entity-details__relations"
+      )
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelector(".entity-details__action-logs")
+    ).not.toBeInTheDocument();
+  });
+
+  it("can display the machines table", async () => {
+    state.juju.modelWatcherData = {
+      abc123: modelWatcherModelDataFactory.build({
+        applications: {
+          "ceph-mon": applicationInfoFactory.build(),
+        },
+        machines: {
+          "0": machineChangeDeltaFactory.build(),
+        },
+        relations: {
+          "wordpress:db mysql:db": relationChangeDeltaFactory.build(),
+        },
+      }),
+    };
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={["/models/eggman@external/test1?activeView=machines"]}
+        >
+          <QueryParamProvider adapter={ReactRouter6Adapter}>
+            <Routes>
+              <Route path="/models/:userName/:modelName" element={<Model />} />
+            </Routes>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    Element.prototype.scrollIntoView = jest.fn();
+
+    expect(
+      document.querySelector(".entity-details__main > .entity-details__apps")
+    ).not.toBeInTheDocument();
     expect(
       document.querySelector(
         ".entity-details__main > .entity-details__machines"
       )
     ).toBeInTheDocument();
-    await userEvent.click(screen.getByTestId("tab-link-Integrations"));
+    expect(
+      document.querySelector(
+        ".entity-details__main > .entity-details__relations"
+      )
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelector(".entity-details__action-logs")
+    ).not.toBeInTheDocument();
+  });
+
+  it("can display the relations table", async () => {
+    state.juju.modelWatcherData = {
+      abc123: modelWatcherModelDataFactory.build({
+        applications: {
+          "ceph-mon": applicationInfoFactory.build(),
+        },
+        machines: {
+          "0": machineChangeDeltaFactory.build(),
+        },
+        relations: {
+          "wordpress:db mysql:db": relationChangeDeltaFactory.build(),
+        },
+      }),
+    };
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            "/models/eggman@external/test1?activeView=integrations",
+          ]}
+        >
+          <QueryParamProvider adapter={ReactRouter6Adapter}>
+            <Routes>
+              <Route path="/models/:userName/:modelName" element={<Model />} />
+            </Routes>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    Element.prototype.scrollIntoView = jest.fn();
+
+    expect(
+      document.querySelector(".entity-details__main > .entity-details__apps")
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelector(
+        ".entity-details__main > .entity-details__machines"
+      )
+    ).not.toBeInTheDocument();
     expect(
       document.querySelector(
         ".entity-details__main > .entity-details__relations"
       )
     ).toBeInTheDocument();
-    await userEvent.click(screen.getByTestId("tab-link-Applications"));
+    expect(
+      document.querySelector(".entity-details__action-logs")
+    ).not.toBeInTheDocument();
+  });
+
+  it("can display the action logs table", async () => {
+    state.juju.modelWatcherData = {
+      abc123: modelWatcherModelDataFactory.build({
+        applications: {
+          "ceph-mon": applicationInfoFactory.build(),
+        },
+        machines: {
+          "0": machineChangeDeltaFactory.build(),
+        },
+        relations: {
+          "wordpress:db mysql:db": relationChangeDeltaFactory.build(),
+        },
+      }),
+    };
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[
+            "/models/eggman@external/test1?activeView=action-logs",
+          ]}
+        >
+          <QueryParamProvider adapter={ReactRouter6Adapter}>
+            <Routes>
+              <Route path="/models/:userName/:modelName" element={<Model />} />
+            </Routes>
+          </QueryParamProvider>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    Element.prototype.scrollIntoView = jest.fn();
+
     expect(
       document.querySelector(".entity-details__main > .entity-details__apps")
-    ).toBeInTheDocument();
-    await userEvent.click(screen.getByTestId("tab-link-Action Logs"));
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelector(
+        ".entity-details__main > .entity-details__machines"
+      )
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelector(
+        ".entity-details__main > .entity-details__relations"
+      )
+    ).not.toBeInTheDocument();
     expect(
       document.querySelector(".entity-details__action-logs")
     ).toBeInTheDocument();
@@ -521,20 +713,5 @@ describe("Model", () => {
     expect(
       screen.getByRole("button", { name: Label.ACCESS_BUTTON })
     ).toBeInTheDocument();
-  });
-  it("shows the search & filter box in the apps tab", async () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/models/eggman@external/group-test"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(screen.getByTestId("filter-applications")).toBeInTheDocument();
   });
 });

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -1,5 +1,5 @@
 import { MainTable } from "@canonical/react-components";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 import {
@@ -30,7 +30,6 @@ import {
 import InfoPanel from "components/InfoPanel/InfoPanel";
 
 import EntityInfo from "components/EntityInfo/EntityInfo";
-import EntityDetails from "pages/EntityDetails/EntityDetails";
 import ActionLogs from "pages/EntityDetails/Model/ActionLogs/ActionLogs";
 
 import useActiveUser from "hooks/useActiveUser";
@@ -48,7 +47,6 @@ import {
 
 import type { EntityDetailsRoute } from "components/Routes/Routes";
 
-import SearchBox from "components/SearchBox/SearchBox";
 import ApplicationsTab from "./ApplicationsTab/ApplicationsTab";
 
 export enum Label {
@@ -86,7 +84,7 @@ const Model = () => {
 
   const { userName, modelName } = useParams<EntityDetailsRoute>();
 
-  const [query, setQuery] = useQueryParams({
+  const [query] = useQueryParams({
     panel: StringParam,
     entity: StringParam,
     activeView: withDefault(StringParam, "apps"),
@@ -121,42 +119,15 @@ const Model = () => {
   const modelInfoData = useSelector(getModelInfo(modelUUID));
 
   const setPanelQs = useQueryParam("panel", StringParam)[1];
-  const searchBoxRef = useRef<HTMLInputElement>(null);
   const [applicationsFilterQuery, setApplicationsFilterQuery] =
     useState<string>(query.filterQuery || "");
 
   useEffect(() => {
     setApplicationsFilterQuery(query.filterQuery);
-    // set value
-    if (searchBoxRef.current) searchBoxRef.current.value = query.filterQuery;
   }, [query.filterQuery]);
 
-  const handleFilterSubmit = () => {
-    const filterQuery = searchBoxRef.current?.value || "";
-    setQuery({ filterQuery });
-  };
-
   return (
-    <EntityDetails
-      type="model"
-      additionalHeaderContent={
-        shouldShow("apps", query.activeView) ? (
-          <SearchBox
-            className="u-no-margin"
-            placeholder="Filter applications"
-            onKeyDown={(e) => {
-              if (e.code === "Enter") handleFilterSubmit();
-            }}
-            onSearch={handleFilterSubmit}
-            onClear={handleFilterSubmit}
-            externallyControlled
-            ref={searchBoxRef}
-            data-testid="filter-applications"
-          />
-        ) : undefined
-      }
-      onApplicationsFilter={(q) => setApplicationsFilterQuery(q)}
-    >
+    <>
       <div>
         <InfoPanel />
         <div className="entity-details__actions">
@@ -270,7 +241,7 @@ const Model = () => {
         )}
         {shouldShow("action-logs", query.activeView) && <ActionLogs />}
       </div>
-    </EntityDetails>
+    </>
   );
 };
 

--- a/src/pages/EntityDetails/Unit/Unit.tsx
+++ b/src/pages/EntityDetails/Unit/Unit.tsx
@@ -19,7 +19,6 @@ import { extractRevisionNumber } from "store/juju/utils/models";
 
 import EntityInfo from "components/EntityInfo/EntityInfo";
 import InfoPanel from "components/InfoPanel/InfoPanel";
-import EntityDetails from "pages/EntityDetails/EntityDetails";
 
 import {
   getAllModelApplicationStatus,
@@ -97,7 +96,7 @@ export default function Unit() {
   }
 
   return (
-    <EntityDetails type="unit">
+    <>
       <div>
         <InfoPanel />
         <EntityInfo data={unitEntityData} />
@@ -122,6 +121,6 @@ export default function Unit() {
           />
         </div>
       </div>
-    </EntityDetails>
+    </>
   );
 }

--- a/src/pages/ModelDetails/ModelDetails.tsx
+++ b/src/pages/ModelDetails/ModelDetails.tsx
@@ -15,6 +15,7 @@ import Machine from "pages/EntityDetails/Machine/Machine";
 import { useAppStore } from "store/store";
 import { Connection } from "@canonical/jujulib";
 import { AllWatcherId } from "@canonical/jujulib/dist/api/facades/client/ClientV6";
+import EntityDetails from "pages/EntityDetails/EntityDetails";
 
 export default function ModelDetails() {
   const appState = useAppStore().getState();
@@ -59,10 +60,12 @@ export default function ModelDetails() {
 
   return (
     <Routes>
-      <Route path="/" element={<Model />} />
-      <Route path="app/:appName" element={<App />} />
-      <Route path="app/:appName/unit/:unitId" element={<Unit />} />
-      <Route path="machine/:machineId" element={<Machine />} />
+      <Route path="*" element={<EntityDetails />}>
+        <Route path="" element={<Model />} />
+        <Route path="app/:appName" element={<App />} />
+        <Route path="app/:appName/unit/:unitId" element={<Unit />} />
+        <Route path="machine/:machineId" element={<Machine />} />
+      </Route>
     </Routes>
   );
 }


### PR DESCRIPTION
## Done

- Refactor EntityDetails so it wraps subroutes.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to a model details page.
- Check that the search box is only visible for the applications tab.
- Check that you can navigate to unit/machine/app details and that the tabs disappear and the breadcrumbs appear.

## Details

https://warthogs.atlassian.net/browse/WD-2831
Fixes: #959.
