### PR TITLE
WD-2832 - Fixed extra tab over hidden config buttons

### DIFF
--- a/src/components/DivButton/DivButton.test.tsx
+++ b/src/components/DivButton/DivButton.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import DivButton from "./DivButton";
+
+describe("DivButton", () => {
+  it("calls the on-click handler when clicked", async () => {
+    const onClick = jest.fn();
+    render(<DivButton onClick={onClick} />);
+    await userEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("calls the on-click handler when space is pressed", async () => {
+    const onClick = jest.fn();
+    render(<DivButton onClick={onClick} />);
+    await userEvent.type(screen.getByRole("button"), " ");
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("calls the on-click handler when enter is pressed", async () => {
+    const onClick = jest.fn();
+    render(<DivButton onClick={onClick} />);
+    await userEvent.type(screen.getByRole("button"), "{enter}");
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("does not call the on-click handler when another key is pressed", async () => {
+    const onClick = jest.fn();
+    render(<DivButton onClick={onClick} />);
+    await userEvent.type(screen.getByRole("button"), "{shift}", {
+      skipClick: true,
+    });
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/DivButton/DivButton.tsx
+++ b/src/components/DivButton/DivButton.tsx
@@ -1,12 +1,12 @@
 import type { PropsWithSpread } from "@canonical/react-components";
-import { HTMLProps, PropsWithChildren } from "react";
+import { HTMLProps, KeyboardEvent, MouseEvent, PropsWithChildren } from "react";
 import classnames from "classnames";
 
 import "./_div-button.scss";
 
 type Props = PropsWithSpread<
   {
-    onClick: () => void;
+    onClick: (event: MouseEvent | KeyboardEvent) => void;
   },
   HTMLProps<HTMLDivElement>
 > &
@@ -20,10 +20,10 @@ const DivButton = ({ children, onClick, className, ...props }: Props) => {
   return (
     <div
       className={classnames("p-div-button", className)}
-      onClick={() => onClick()}
+      onClick={(event) => onClick(event)}
       onKeyDown={(event) => {
         if (event.key === " " || event.key === "Enter") {
-          onClick();
+          onClick(event);
         }
       }}
       role="button"

--- a/src/components/DivButton/DivButton.tsx
+++ b/src/components/DivButton/DivButton.tsx
@@ -1,5 +1,11 @@
 import type { PropsWithSpread } from "@canonical/react-components";
-import { HTMLProps, KeyboardEvent, MouseEvent, PropsWithChildren } from "react";
+import {
+  HTMLProps,
+  KeyboardEvent,
+  MouseEvent,
+  PropsWithChildren,
+  useRef,
+} from "react";
 import classnames from "classnames";
 
 import "./_div-button.scss";
@@ -17,15 +23,22 @@ type Props = PropsWithSpread<
  element wraps another interactive element.
  */
 const DivButton = ({ children, onClick, className, ...props }: Props) => {
+  const ref = useRef(null);
   return (
     <div
       className={classnames("p-div-button", className)}
       onClick={(event) => onClick(event)}
       onKeyDown={(event) => {
-        if (event.key === " " || event.key === "Enter") {
+        if (
+          // Check that this element has focus so that this doesn't fire when
+          // interacting with children.
+          document.activeElement === ref.current &&
+          (event.key === " " || event.key === "Enter")
+        ) {
           onClick(event);
         }
       }}
+      ref={ref}
       role="button"
       tabIndex={0}
       {...props}

--- a/src/components/DivButton/DivButton.tsx
+++ b/src/components/DivButton/DivButton.tsx
@@ -1,0 +1,38 @@
+import type { PropsWithSpread } from "@canonical/react-components";
+import { HTMLProps, PropsWithChildren } from "react";
+import classnames from "classnames";
+
+import "./_div-button.scss";
+
+type Props = PropsWithSpread<
+  {
+    onClick: () => void;
+  },
+  HTMLProps<HTMLDivElement>
+> &
+  PropsWithChildren;
+
+/**
+ This component can be used where a button can't be, e.g. when an interactive
+ element wraps another interactive element.
+ */
+const DivButton = ({ children, onClick, className, ...props }: Props) => {
+  return (
+    <div
+      className={classnames("p-div-button", className)}
+      onClick={() => onClick()}
+      onKeyDown={(event) => {
+        if (event.key === " " || event.key === "Enter") {
+          onClick();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default DivButton;

--- a/src/components/DivButton/_div-button.scss
+++ b/src/components/DivButton/_div-button.scss
@@ -1,0 +1,3 @@
+.p-div-button {
+  cursor: pointer;
+}

--- a/src/components/DivButton/index.ts
+++ b/src/components/DivButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DivButton";

--- a/src/panels/ConfigPanel/ConfigField.tsx
+++ b/src/panels/ConfigPanel/ConfigField.tsx
@@ -143,7 +143,10 @@ const ConfigField = <V,>({
         "config-input--changed": inputChanged,
       })}
       data-testid={config.name}
-      onClick={() => setSelectedConfig(config)}
+      onClick={(event) => {
+        event.preventDefault();
+        setSelectedConfig(config);
+      }}
     >
       <h5 className="u-float-left">
         {config.description ? (

--- a/src/panels/ConfigPanel/ConfigField.tsx
+++ b/src/panels/ConfigPanel/ConfigField.tsx
@@ -11,6 +11,7 @@ import classnames from "classnames";
 import { isSet } from "components/utils";
 import { ConfigData } from "juju/api";
 import { Button, Icon } from "@canonical/react-components";
+import DivButton from "components/DivButton";
 
 export type SetNewValue = (name: string, value: any) => void;
 
@@ -136,9 +137,7 @@ const ConfigField = <V,>({
   }
 
   return (
-    // XXX How to tell aria to ignore the click but not the element?
-    // eslint-disable-next-line
-    <div
+    <DivButton
       className={classnames("config-input", {
         "config-input--focused": inputFocused,
         "config-input--changed": inputChanged,
@@ -166,6 +165,8 @@ const ConfigField = <V,>({
           }
         )}
         onClick={resetToDefault}
+        tabIndex={showUseDefault ? 0 : -1}
+        aria-hidden={!showUseDefault}
       >
         use default
       </button>
@@ -178,7 +179,7 @@ const ConfigField = <V,>({
         </pre>
       </div>
       {input(inputValue)}
-    </div>
+    </DivButton>
   );
 };
 

--- a/src/panels/ConfigPanel/TextAreaConfig.tsx
+++ b/src/panels/ConfigPanel/TextAreaConfig.tsx
@@ -18,7 +18,7 @@ export default function TextAreaConfig({
       input={(value) => (
         <textarea
           ref={inputRef}
-          value={value}
+          value={value ?? ""}
           onFocus={() => setSelectedConfig(config)}
           onChange={(e) => {
             setNewValue(config.name, e.target.value);

--- a/src/panels/ConfigPanel/_config-panel.scss
+++ b/src/panels/ConfigPanel/_config-panel.scss
@@ -208,7 +208,6 @@ $panel-padding: 1.5rem;
   border: 1px solid transparent;
   border-radius: 2px;
   border-radius: $border-radius;
-  cursor: pointer;
   margin-bottom: $spv--small;
   padding: 0 0.5rem;
 


### PR DESCRIPTION
## Done

- Fixed extra tab over hidden config buttons.
- Improved accessibility of config items.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to an app and open the config panel.
- Click inside an input.
- Press tab once and the next config item should be highlighted.
- Press enter or space and the help on the right should update.
- Press tab again and (assuming you haven't changed the value from the default) the focus should move to the input.
- Change one of the values so that the 'use default' button appears and check that you can tab to that button.

## Details

Fixes: #862.
https://warthogs.atlassian.net/browse/WD-2832