### PR TITLE
WD-2857 - Sticky entity details sidebar

### DIFF
--- a/src/components/InfoPanel/_info-panel.scss
+++ b/src/components/InfoPanel/_info-panel.scss
@@ -34,7 +34,7 @@
       position: absolute;
       right: 10px;
 
-      @include medium {
+      @include desktop {
         display: inline-block;
       }
     }

--- a/src/components/ModelTableList/StatusGroup.tsx
+++ b/src/components/ModelTableList/StatusGroup.tsx
@@ -177,7 +177,7 @@ function generateModelTableDataByStatus(
         // e.g. 2021-01-01 becomes 21-01-01
         lastUpdated = lastUpdated.slice(2);
       }
-      modelData[`${groupLabel}Rows`].push({
+      const row = {
         "data-testid": `model-uuid-${model?.uuid}`,
         columns: [
           {
@@ -245,9 +245,8 @@ function generateModelTableDataByStatus(
           controller,
           lastUpdated,
         },
-        // TSFixMe this is required until react-components includes template
-        // literals for data properties.
-      } as MainTableRow);
+      };
+      modelData[`${groupLabel}Rows`].push(row);
     });
   });
 

--- a/src/components/Topology/Topology.tsx
+++ b/src/components/Topology/Topology.tsx
@@ -166,7 +166,7 @@ const Topology = memo(
 
     // Apply deltas to the annotations.
     for (const appName in annotationData) {
-      const annotation = annotationData[appName];
+      const annotation = { ...annotationData[appName] };
       if (annotation["gui-x"]) {
         annotation["gui-x"] = applyDelta(
           annotation["gui-x"],

--- a/src/layout/BaseLayout/_base-layout.scss
+++ b/src/layout/BaseLayout/_base-layout.scss
@@ -48,6 +48,9 @@
 
 .l-main {
   background-color: $color-x-light;
+  // Override the Vanilla default that sets overflow-y to auto but this prevents
+  // sticky from being used by the the entity details sidebar.
+  overflow-y: visible !important;
 
   @include large {
     padding-left: 3rem;
@@ -135,6 +138,9 @@
 
 .l-application {
   overflow-x: hidden;
+  // Override the Vanilla default that sets overflow-y to hidden but this prevents
+  // sticky from being used by the the entity details sidebar.
+  overflow-y: visible !important;
 
   .l-navigation.is-pinned + .l-main {
     padding-left: 0;

--- a/src/pages/EntityDetails/Model/ActionLogs/ActionLogs.tsx
+++ b/src/pages/EntityDetails/Model/ActionLogs/ActionLogs.tsx
@@ -198,7 +198,7 @@ export default function ActionLogs() {
         const actionFullDetails = actions.find(
           (action) => action.action.tag === actionData.action.tag
         );
-        delete actionFullDetails?.output["return-code"];
+        delete actionFullDetails?.output?.["return-code"];
         if (!actionFullDetails) return;
         const stdout = (actionFullDetails.log || []).map((m, i) => (
           <span className="action-logs__stdout" key={i}>

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -134,35 +134,40 @@ const Model = () => {
   return (
     <>
       <div>
-        <InfoPanel />
-        <div className="entity-details__actions">
-          {canAdministerModelAccess(
-            activeUser,
-            modelStatusData?.info?.users
-          ) && (
-            <button
-              className="entity-details__action-button"
-              onClick={() => setPanelQs("share-model")}
-            >
-              <i className="p-icon--share"></i>
-              {Label.ACCESS_BUTTON}
-            </button>
+        {/* The sidebar needs to be within a wrapping div so that it does not
+            get given the full height of the grid so that the sidebar can be sticky.
+        */}
+        <div className="entity-details__sidebar">
+          <InfoPanel />
+          <div className="entity-details__actions">
+            {canAdministerModelAccess(
+              activeUser,
+              modelStatusData?.info?.users
+            ) && (
+              <button
+                className="entity-details__action-button"
+                onClick={() => setPanelQs("share-model")}
+              >
+                <i className="p-icon--share"></i>
+                {Label.ACCESS_BUTTON}
+              </button>
+            )}
+          </div>
+          {modelInfoData && (
+            <EntityInfo
+              data={{
+                access: modelAccess ?? "Unknown",
+                controller: modelInfoData.type,
+                "Cloud/Region": generateCloudAndRegion(
+                  modelInfoData["cloud-tag"],
+                  modelInfoData.region
+                ),
+                version: modelInfoData.version,
+                sla: modelInfoData.sla?.level,
+              }}
+            />
           )}
         </div>
-        {modelInfoData && (
-          <EntityInfo
-            data={{
-              access: modelAccess ?? "Unknown",
-              controller: modelInfoData.type,
-              "Cloud/Region": generateCloudAndRegion(
-                modelInfoData["cloud-tag"],
-                modelInfoData.region
-              ),
-              version: modelInfoData.version,
-              sla: modelInfoData.sla?.level,
-            }}
-          />
-        )}
       </div>
       <div className="entity-details__main u-overflow--auto">
         {shouldShow("apps", query.activeView) && (

--- a/src/pages/EntityDetails/_entity-details.scss
+++ b/src/pages/EntityDetails/_entity-details.scss
@@ -11,7 +11,6 @@
     grid-template-columns: 1fr;
     margin-bottom: 0;
     max-width: 100%;
-    overflow: hidden;
     padding-bottom: 0;
     padding-top: 1rem;
 
@@ -67,6 +66,11 @@
       strong {
         margin-right: 1rem;
       }
+    }
+
+    &__sidebar {
+      position: sticky;
+      top: $top-header-height + 1.5rem;
     }
 
     @include desktop {

--- a/src/scss/_vanilla-overrides.scss
+++ b/src/scss/_vanilla-overrides.scss
@@ -14,3 +14,12 @@
 .p-tooltip__message {
   z-index: z("zelda") + 1;
 }
+
+@media (min-width: $breakpoint-large) {
+  body {
+    // Override the Vanilla default which sets the position to relative only on
+    // large screens. This was causing issues with scrolling the main content in
+    // Safari.
+    position: unset !important;
+  }
+}


### PR DESCRIPTION
## Done

- Make the entity details sidebar sticky.
- A bunch of small drive-by fixes which were discovered while working on this change.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to a model details page that has longer content than the details sidebar (you might need to add a lot of applications or run a lot of actions).
- Resize your window so that the content doesn't fit on the screen.
- Scroll the content and the details sidebar should not scroll unless it doesn't fit on the screen.
- Try different screen sizes and browsers and check that something hasn't broken.

## Details

https://warthogs.atlassian.net/browse/WD-2857
Fixes: #517.

## Screenshots

![Screen Recording 2023-03-28 at 11 08 08 am](https://user-images.githubusercontent.com/361637/228094285-c134b126-6121-4a3b-9513-a65b3291dff8.gif)

