### PR TITLE
WD-2883 - Replace use-query-params

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "redux-mock-store": "1.5.4",
     "redux-thunk": "2.4.2",
     "reselect": "4.1.7",
-    "use-query-params": "2.1.2",
     "vanilla-framework": "3.11.1"
   },
   "devDependencies": {

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,7 +1,5 @@
 import { useSelector } from "react-redux";
 import { BrowserRouter as Router } from "react-router-dom";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 import { initialize, pageview } from "react-ga";
 
 import ErrorBoundary from "components/ErrorBoundary/ErrorBoundary";
@@ -25,9 +23,7 @@ function App() {
   return (
     <Router basename={baseAppURL}>
       <ErrorBoundary>
-        <QueryParamProvider adapter={ReactRouter6Adapter}>
-          <Routes />
-        </QueryParamProvider>
+        <Routes />
       </ErrorBoundary>
     </Router>
   );

--- a/src/components/InfoPanel/InfoPanel.test.tsx
+++ b/src/components/InfoPanel/InfoPanel.test.tsx
@@ -2,8 +2,6 @@ import { act, render, screen, waitFor } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import { jujuStateFactory, rootStateFactory } from "testing/factories";
 import {
@@ -57,14 +55,12 @@ describe("Info Panel", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/models/kirk@external/enterprise"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route
-                path="/models/:userName/:modelName"
-                element={<InfoPanel />}
-              />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route
+              path="/models/:userName/:modelName"
+              element={<InfoPanel />}
+            />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -76,14 +72,12 @@ describe("Info Panel", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/models/kirk@external/enterprise"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route
-                path="/models/:userName/:modelName"
-                element={<InfoPanel />}
-              />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route
+              path="/models/:userName/:modelName"
+              element={<InfoPanel />}
+            />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );

--- a/src/components/ModelTableList/CloudGroup.js
+++ b/src/components/ModelTableList/CloudGroup.js
@@ -1,7 +1,7 @@
 import { useSelector } from "react-redux";
 import { MainTable } from "@canonical/react-components";
-import { useQueryParams, StringParam, withDefault } from "use-query-params";
 
+import { useQueryParams } from "hooks/useQueryParams";
 import {
   getModelStatusGroupData,
   extractOwnerName,
@@ -78,10 +78,10 @@ export default function CloudGroup({ filters }) {
     getGroupedByCloudAndFilteredModelData(filters)
   );
 
-  const setPanelQs = useQueryParams({
-    model: StringParam,
-    panel: withDefault(StringParam, "share-model"),
-  })[1];
+  const [, setPanelQs] = useQueryParams({
+    model: null,
+    panel: null,
+  });
 
   const cloudRows = generateModelTableDataByCloud(groupedAndFilteredData);
   let cloudTables = [];

--- a/src/components/ModelTableList/CloudGroup.test.tsx
+++ b/src/components/ModelTableList/CloudGroup.test.tsx
@@ -2,8 +2,6 @@ import { MemoryRouter } from "react-router";
 import { Provider } from "react-redux";
 import { render, screen, within } from "@testing-library/react";
 import configureStore from "redux-mock-store";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import {
   jujuStateFactory,
@@ -71,9 +69,7 @@ describe("CloudGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <CloudGroup filters={[]} />
-          </QueryParamProvider>
+          <CloudGroup filters={[]} />
         </Provider>
       </MemoryRouter>
     );
@@ -85,9 +81,7 @@ describe("CloudGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <CloudGroup filters={[]} />
-          </QueryParamProvider>
+          <CloudGroup filters={[]} />
         </Provider>
       </MemoryRouter>
     );
@@ -105,9 +99,7 @@ describe("CloudGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <CloudGroup filters={filters} />
-          </QueryParamProvider>
+          <CloudGroup filters={filters} />
         </Provider>
       </MemoryRouter>
     );
@@ -149,9 +141,7 @@ describe("CloudGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <CloudGroup filters={filters} />
-          </QueryParamProvider>
+          <CloudGroup filters={filters} />
         </Provider>
       </MemoryRouter>
     );

--- a/src/components/ModelTableList/ModelTableList.test.tsx
+++ b/src/components/ModelTableList/ModelTableList.test.tsx
@@ -2,8 +2,6 @@ import { MemoryRouter } from "react-router";
 import { render, RenderResult, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import * as appSelectors from "store/juju/selectors";
 import { RootState } from "store/store";
@@ -46,9 +44,7 @@ describe("ModelTableList", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ModelTableList filters={[]} groupedBy="" />
-          </QueryParamProvider>
+          <ModelTableList filters={[]} groupedBy="" />
         </Provider>
       </MemoryRouter>
     );
@@ -67,11 +63,9 @@ describe("ModelTableList", () => {
     ];
     const generateComponent = (groupedBy: string) => (
       <MemoryRouter>
-        <QueryParamProvider adapter={ReactRouter6Adapter}>
-          <Provider store={store}>
-            <ModelTableList filters={[]} groupedBy={groupedBy} />
-          </Provider>
-        </QueryParamProvider>
+        <Provider store={store}>
+          <ModelTableList filters={[]} groupedBy={groupedBy} />
+        </Provider>
       </MemoryRouter>
     );
     let result: RenderResult;
@@ -106,9 +100,7 @@ describe("ModelTableList", () => {
       render(
         <MemoryRouter>
           <Provider store={store}>
-            <QueryParamProvider adapter={ReactRouter6Adapter}>
-              <ModelTableList groupedBy={table.groupedBy} filters={filters} />
-            </QueryParamProvider>
+            <ModelTableList groupedBy={table.groupedBy} filters={filters} />
           </Provider>
         </MemoryRouter>
       );
@@ -135,9 +127,7 @@ describe("ModelTableList", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ModelTableList filters={[]} groupedBy="" />
-          </QueryParamProvider>
+          <ModelTableList filters={[]} groupedBy="" />
         </Provider>
       </MemoryRouter>
     );
@@ -157,9 +147,7 @@ describe("ModelTableList", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ModelTableList filters={[]} groupedBy="" />
-          </QueryParamProvider>
+          <ModelTableList filters={[]} groupedBy="" />
         </Provider>
       </MemoryRouter>
     );
@@ -189,9 +177,7 @@ describe("ModelTableList", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ModelTableList filters={[]} groupedBy="" />
-          </QueryParamProvider>
+          <ModelTableList filters={[]} groupedBy="" />
         </Provider>
       </MemoryRouter>
     );

--- a/src/components/ModelTableList/OwnerGroup.js
+++ b/src/components/ModelTableList/OwnerGroup.js
@@ -1,7 +1,7 @@
 import { MainTable } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { StringParam, useQueryParams, withDefault } from "use-query-params";
 
+import { useQueryParams } from "hooks/useQueryParams";
 import {
   canAdministerModelAccess,
   getModelStatusGroupData,
@@ -75,10 +75,10 @@ export default function OwnerGroup({ filters }) {
     getGroupedByOwnerAndFilteredModelData(filters)
   );
   const ownerRows = generateModelTableDataByOwner(groupedAndFilteredData);
-  const setPanelQs = useQueryParams({
-    model: StringParam,
-    panel: withDefault(StringParam, "share-model"),
-  })[1];
+  const [, setPanelQs] = useQueryParams({
+    model: null,
+    panel: null,
+  });
   const activeUsers = useSelector(getActiveUsers);
   const controllers = useSelector(getControllerData);
 

--- a/src/components/ModelTableList/OwnerGroup.test.tsx
+++ b/src/components/ModelTableList/OwnerGroup.test.tsx
@@ -2,8 +2,6 @@ import { MemoryRouter } from "react-router";
 import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import { rootStateFactory } from "testing/factories/root";
 import { generalStateFactory, configFactory } from "testing/factories/general";
@@ -74,9 +72,7 @@ describe("OwnerGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <OwnerGroup filters={[]} />
-          </QueryParamProvider>
+          <OwnerGroup filters={[]} />
         </Provider>
       </MemoryRouter>
     );
@@ -88,9 +84,7 @@ describe("OwnerGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <OwnerGroup filters={[]} />
-          </QueryParamProvider>
+          <OwnerGroup filters={[]} />
         </Provider>
       </MemoryRouter>
     );
@@ -108,9 +102,7 @@ describe("OwnerGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <OwnerGroup filters={filters} />
-          </QueryParamProvider>
+          <OwnerGroup filters={filters} />
         </Provider>
       </MemoryRouter>
     );
@@ -150,9 +142,7 @@ describe("OwnerGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <OwnerGroup filters={filters} />
-          </QueryParamProvider>
+          <OwnerGroup filters={filters} />
         </Provider>
       </MemoryRouter>
     );

--- a/src/components/ModelTableList/StatusGroup.test.tsx
+++ b/src/components/ModelTableList/StatusGroup.test.tsx
@@ -3,8 +3,6 @@ import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import { RootState } from "store/store";
 import { rootStateFactory } from "testing/factories";
@@ -101,9 +99,7 @@ describe("StatusGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <StatusGroup filters={{}} />
-          </QueryParamProvider>
+          <StatusGroup filters={{}} />
         </Provider>
       </MemoryRouter>
     );
@@ -115,9 +111,7 @@ describe("StatusGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <StatusGroup filters={{}} />
-          </QueryParamProvider>
+          <StatusGroup filters={{}} />
         </Provider>
       </MemoryRouter>
     );
@@ -136,9 +130,7 @@ describe("StatusGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <StatusGroup filters={filters} />
-          </QueryParamProvider>
+          <StatusGroup filters={filters} />
         </Provider>
       </MemoryRouter>
     );
@@ -150,9 +142,7 @@ describe("StatusGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <StatusGroup filters={{}} />
-          </QueryParamProvider>
+          <StatusGroup filters={{}} />
         </Provider>
       </MemoryRouter>
     );
@@ -195,9 +185,7 @@ describe("StatusGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <StatusGroup filters={filters} />
-          </QueryParamProvider>
+          <StatusGroup filters={filters} />
         </Provider>
       </MemoryRouter>
     );
@@ -237,9 +225,7 @@ describe("StatusGroup", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <StatusGroup filters={{}} />
-          </QueryParamProvider>
+          <StatusGroup filters={{}} />
         </Provider>
       </MemoryRouter>
     );

--- a/src/components/ModelTableList/StatusGroup.tsx
+++ b/src/components/ModelTableList/StatusGroup.tsx
@@ -3,14 +3,8 @@ import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import { List, MainTable, Tooltip } from "@canonical/react-components";
 import { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
-import {
-  useQueryParams,
-  StringParam,
-  withDefault,
-  QueryParamConfig,
-  SetQuery,
-} from "use-query-params";
 
+import { useQueryParams, SetParams } from "hooks/useQueryParams";
 import {
   getModelStatusGroupData,
   extractOwnerName,
@@ -146,12 +140,7 @@ const generateModelNameCell = (model: ModelData, groupLabel: string) => {
 */
 function generateModelTableDataByStatus(
   groupedModels: Record<Status, ModelData[]>,
-  setPanelQs: SetQuery<
-    Record<
-      string,
-      QueryParamConfig<string | null | undefined, string | null | undefined>
-    >
-  >,
+  setPanelQs: SetParams<Record<string, unknown>>,
   activeUsers: Record<string, string>,
   controllers: Controllers | null
 ) {
@@ -260,10 +249,10 @@ export default function StatusGroup({ filters }: { filters: Filters }) {
     getGroupedByStatusAndFilteredModelData(filters)
   );
   const controllers = useSelector(getControllerData);
-  const setPanelQs = useQueryParams({
-    model: StringParam,
-    panel: withDefault(StringParam, "share-model"),
-  })[1];
+  const [, setPanelQs] = useQueryParams({
+    model: null,
+    panel: null,
+  });
   const activeUsers = useSelector(getActiveUsers);
 
   const { blockedRows, alertRows, runningRows } =

--- a/src/components/ModelTableList/shared.tsx
+++ b/src/components/ModelTableList/shared.tsx
@@ -12,7 +12,7 @@ import {
   extractCloudName,
   extractCredentialName,
 } from "store/juju/utils/models";
-import { QueryParamConfig, SetQuery } from "use-query-params";
+import { SetParams } from "hooks/useQueryParams";
 
 export const JAAS_CONTROLLER_UUID = "a030379a-940f-4760-8fcf-3062b41a04e7";
 
@@ -274,12 +274,7 @@ export function generateCloudAndRegion(model: ModelData) {
   @returns The markup for the table cell
 */
 export function generateAccessButton(
-  setPanelQs: SetQuery<
-    Record<
-      string,
-      QueryParamConfig<string | null | undefined, string | null | undefined>
-    >
-  >,
+  setPanelQs: SetParams<Record<string, unknown>>,
   modelName: string
 ) {
   return (

--- a/src/components/PanelHeader/PanelHeader.test.tsx
+++ b/src/components/PanelHeader/PanelHeader.test.tsx
@@ -1,7 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 import { BrowserRouter, MemoryRouter } from "react-router-dom";
 
 import PanelHeader from "./PanelHeader";
@@ -13,9 +11,7 @@ describe("PanelHeader", () => {
       <MemoryRouter
         initialEntries={["/models/user-eggman@external/new-search-aggregate"]}
       >
-        <QueryParamProvider adapter={ReactRouter6Adapter}>
-          <PanelHeader title={title} />
-        </QueryParamProvider>
+        <PanelHeader title={title} />
       </MemoryRouter>
     );
     expect(screen.getByText(title)).toHaveClass("p-panel__title");
@@ -25,9 +21,7 @@ describe("PanelHeader", () => {
     window.history.pushState({}, "", "/models?model=cmr&panel=share-model");
     render(
       <BrowserRouter>
-        <QueryParamProvider adapter={ReactRouter6Adapter}>
-          <PanelHeader title="Title" />
-        </QueryParamProvider>
+        <PanelHeader title="Title" />
       </BrowserRouter>
     );
     const searchParams = new URLSearchParams(window.location.search);

--- a/src/components/PanelHeader/PanelHeader.tsx
+++ b/src/components/PanelHeader/PanelHeader.tsx
@@ -1,24 +1,14 @@
+import { useQueryParams } from "hooks/useQueryParams";
 import { ReactNode } from "react";
-import { useQueryParams, StringParam } from "use-query-params";
 
 type Props = {
   title: ReactNode;
 };
 
-type QueryString = {
-  [key: string]: string | undefined;
-};
-
 export default function PanelHeader({ title }: Props): JSX.Element {
-  const [panelQs, setPanelQs] = useQueryParams({
-    panel: StringParam,
-    model: StringParam,
-  });
-
-  // Remove all query strings when close button is clicked
-  const removalObj: QueryString = {};
-  Object.keys(panelQs).forEach((queryString: string) => {
-    removalObj[queryString] = undefined;
+  const [, setPanelQs] = useQueryParams({
+    panel: null,
+    model: null,
   });
 
   return (
@@ -26,7 +16,7 @@ export default function PanelHeader({ title }: Props): JSX.Element {
       <div className="p-panel__title">{title}</div>
       <div className="p-panel__controls">
         <button
-          onClick={() => setPanelQs(removalObj)}
+          onClick={() => setPanelQs(null)}
           className="p-button--base js-aside-close u-no-margin--bottom has-icon"
         >
           <i className="p-icon--close"></i>

--- a/src/components/hooks.test.tsx
+++ b/src/components/hooks.test.tsx
@@ -1,8 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { Route, Routes, MemoryRouter } from "react-router-dom";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 import { rootStateFactory } from "testing/factories";
 import configureStore from "redux-mock-store";
 
@@ -18,14 +16,12 @@ describe("useEntityDetailsParams", () => {
           <MemoryRouter
             initialEntries={["/models/eggman@external/group-test/machine/0"]}
           >
-            <QueryParamProvider adapter={ReactRouter6Adapter}>
-              <Routes>
-                <Route
-                  path="/models/:userName/:modelName/machine/:machineId"
-                  element={children}
-                />
-              </Routes>
-            </QueryParamProvider>
+            <Routes>
+              <Route
+                path="/models/:userName/:modelName/machine/:machineId"
+                element={children}
+              />
+            </Routes>
           </MemoryRouter>
         </Provider>
       ),
@@ -47,14 +43,12 @@ describe("useEntityDetailsParams", () => {
           <MemoryRouter
             initialEntries={["/models/eggman@external/group-test/applications"]}
           >
-            <QueryParamProvider adapter={ReactRouter6Adapter}>
-              <Routes>
-                <Route
-                  path="/models/:userName/:modelName/applications"
-                  element={children}
-                />
-              </Routes>
-            </QueryParamProvider>
+            <Routes>
+              <Route
+                path="/models/:userName/:modelName/applications"
+                element={children}
+              />
+            </Routes>
           </MemoryRouter>
         </Provider>
       ),
@@ -69,14 +63,12 @@ describe("useEntityDetailsParams", () => {
           <MemoryRouter
             initialEntries={["/models/eggman@external/group-test/app/etcd"]}
           >
-            <QueryParamProvider adapter={ReactRouter6Adapter}>
-              <Routes>
-                <Route
-                  path="/models/:userName/:modelName/app/:appName"
-                  element={children}
-                />
-              </Routes>
-            </QueryParamProvider>
+            <Routes>
+              <Route
+                path="/models/:userName/:modelName/app/:appName"
+                element={children}
+              />
+            </Routes>
           </MemoryRouter>
         </Provider>
       ),

--- a/src/hooks/useModelStatus.ts
+++ b/src/hooks/useModelStatus.ts
@@ -1,8 +1,9 @@
 import { useMemo } from "react";
 import { useParams } from "react-router-dom";
+
 import { getModelUUID, getModelStatus } from "store/juju/selectors";
-import { useQueryParams, StringParam } from "use-query-params";
 import { useAppSelector } from "store/store";
+import { useQueryParams } from "hooks/useQueryParams";
 
 // Return model status data based on model name in URL
 export default function useModelStatus() {
@@ -12,7 +13,7 @@ export default function useModelStatus() {
   // if model name cannot be derived from URL params, fallback and check for
   // query string value.
   const queryParams = useQueryParams({
-    model: StringParam,
+    model: null,
   });
 
   if (!modelName) {

--- a/src/hooks/useQueryParams.test.tsx
+++ b/src/hooks/useQueryParams.test.tsx
@@ -1,0 +1,144 @@
+import { act, renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { rootStateFactory } from "testing/factories";
+import configureStore from "redux-mock-store";
+import { PropsWithChildren } from "react";
+
+import { useQueryParams } from "./useQueryParams";
+
+const mockStore = configureStore();
+
+const generateContainer = ({ children }: PropsWithChildren) => {
+  const store = mockStore(rootStateFactory.build());
+  return (
+    <Provider store={store}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="*" element={children} />
+        </Routes>
+      </BrowserRouter>
+    </Provider>
+  );
+};
+
+describe("useQueryParams", () => {
+  afterEach(() => {
+    window.history.pushState({}, "", "?");
+  });
+
+  it("can return default string params", () => {
+    const { result } = renderHook(
+      () => useQueryParams<{ panel: string | null }>({ panel: "config" }),
+      {
+        wrapper: generateContainer,
+      }
+    );
+    const [searchParams] = result.current;
+    expect(searchParams.panel).toBe("config");
+  });
+
+  it("can return default array params", () => {
+    const { result } = renderHook(
+      () =>
+        useQueryParams<{ panels: string[] }>({ panels: ["config", "actions"] }),
+      {
+        wrapper: generateContainer,
+      }
+    );
+    const [searchParams] = result.current;
+    expect(searchParams.panels).toStrictEqual(["config", "actions"]);
+  });
+
+  it("can return string params from the URL", () => {
+    window.history.pushState({}, "", "?panel=config");
+    const { result } = renderHook(
+      () => useQueryParams<{ panel: string | null }>({ panel: null }),
+      {
+        wrapper: generateContainer,
+      }
+    );
+    const [searchParams] = result.current;
+    expect(searchParams.panel).toBe("config");
+  });
+
+  it("can return array params from the URL", () => {
+    window.history.pushState({}, "", "?panels=config,actions");
+    const { result } = renderHook(
+      () => useQueryParams<{ panels: string[] }>({ panels: [] }),
+      {
+        wrapper: generateContainer,
+      }
+    );
+    const [searchParams] = result.current;
+    expect(searchParams.panels).toStrictEqual(["config", "actions"]);
+  });
+
+  it("can set string params", () => {
+    const { result } = renderHook(
+      () => useQueryParams<{ panel: string | null }>({ panel: null }),
+      {
+        wrapper: generateContainer,
+      }
+    );
+    let [searchParams, setSearchParams] = result.current;
+    expect(searchParams.panel).toBeNull();
+    expect(window.location.search).toBe("");
+    act(() => setSearchParams({ panel: "config" }));
+    [searchParams] = result.current;
+    expect(searchParams.panel).toBe("config");
+    expect(window.location.search).toBe("?panel=config");
+  });
+
+  it("can set array params", () => {
+    const { result } = renderHook(
+      () => useQueryParams<{ panels: string[] }>({ panels: [] }),
+      {
+        wrapper: generateContainer,
+      }
+    );
+    let [searchParams, setSearchParams] = result.current;
+    expect(searchParams.panels).toStrictEqual([]);
+    expect(window.location.search).toBe("");
+    act(() => setSearchParams({ panels: ["config", "actions"] }));
+    [searchParams] = result.current;
+    expect(searchParams.panels).toStrictEqual(["config", "actions"]);
+    expect(window.location.search).toBe("?panels=config%2Cactions");
+  });
+
+  it("can clear a param", () => {
+    window.history.pushState({}, "", "?panel=config&other=something");
+    const { result } = renderHook(
+      () =>
+        useQueryParams<{ panel: string | null; other: string | null }>({
+          panel: null,
+          other: null,
+        }),
+      {
+        wrapper: generateContainer,
+      }
+    );
+    let [searchParams, setSearchParams] = result.current;
+    expect(searchParams.panel).toBe("config");
+    act(() => setSearchParams({ panel: null }));
+    [searchParams] = result.current;
+    expect(searchParams.panel).toBeNull();
+    expect(window.location.search).toBe("?other=something");
+  });
+
+  it("can clear all params", () => {
+    window.history.pushState({}, "", "?panel=config");
+    const { result } = renderHook(
+      () => useQueryParams<{ panel: string | null }>({ panel: null }),
+      {
+        wrapper: generateContainer,
+      }
+    );
+    let [searchParams, setSearchParams] = result.current;
+    expect(searchParams.panel).toBe("config");
+    act(() => setSearchParams(null));
+    [searchParams] = result.current;
+    expect(searchParams.panel).toBeNull();
+    expect(window.location.search).toBe("");
+  });
+});

--- a/src/hooks/useQueryParams.ts
+++ b/src/hooks/useQueryParams.ts
@@ -1,0 +1,48 @@
+import { useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export type SetParams<P> = (params?: Partial<P> | null) => void;
+
+export const useQueryParams = <
+  P extends Record<string, null | string | string[]>
+>(
+  params: P
+): [P, SetParams<P>] => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const setParam = useCallback(
+    (newParams?: Partial<P> | null) => {
+      if (!newParams) {
+        // If this is call with no params then clear all.
+        Array.from(searchParams.keys()).forEach((key) =>
+          searchParams.delete(key)
+        );
+      } else {
+        Object.entries(newParams).forEach(([param, value]) => {
+          if (value === undefined || value === null) {
+            // Clear a param if it has been provided with a null or undefined value.
+            searchParams.delete(param);
+          } else {
+            searchParams.set(param, value);
+          }
+        });
+      }
+      setSearchParams(searchParams);
+    },
+    [searchParams, setSearchParams]
+  );
+
+  searchParams.forEach((value, key) => {
+    if (key in params) {
+      const paramKey = key as keyof P;
+      if (Array.isArray(params[paramKey])) {
+        // Update any array params. If the key is in the URL without a value it
+        // will be returned as an empty string.
+        params[paramKey] = (value === "" ? [] : value.split(",")) as P[keyof P];
+      } else {
+        params[paramKey] = value as P[keyof P];
+      }
+    }
+  });
+  return [params, setParam];
+};

--- a/src/layout/BaseLayout/BaseLayout.test.tsx
+++ b/src/layout/BaseLayout/BaseLayout.test.tsx
@@ -7,8 +7,6 @@ import {
 } from "react-router-dom";
 import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import { rootStateFactory } from "testing/factories/root";
 import { RootState } from "store/store";
@@ -28,11 +26,9 @@ describe("Base Layout", () => {
     render(
       <Provider store={store}>
         <Router>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <BaseLayout>
-              <p>foo</p>
-            </BaseLayout>
-          </QueryParamProvider>
+          <BaseLayout>
+            <p>foo</p>
+          </BaseLayout>
         </Router>
       </Provider>
     );
@@ -44,11 +40,9 @@ describe("Base Layout", () => {
     render(
       <Provider store={store}>
         <Router>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <BaseLayout>
-              <p>foo</p>
-            </BaseLayout>
-          </QueryParamProvider>
+          <BaseLayout>
+            <p>foo</p>
+          </BaseLayout>
         </Router>
       </Provider>
     );
@@ -66,18 +60,16 @@ describe("Base Layout", () => {
             "/models/pizza@external/hadoopspark?activeView=machines",
           ]}
         >
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route
-                path="/models/:userName/:modelName"
-                element={
-                  <BaseLayout>
-                    <p>foo</p>
-                  </BaseLayout>
-                }
-              />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route
+              path="/models/:userName/:modelName"
+              element={
+                <BaseLayout>
+                  <p>foo</p>
+                </BaseLayout>
+              }
+            />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -92,18 +84,16 @@ describe("Base Layout", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/models/"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route
-                path="/models"
-                element={
-                  <BaseLayout>
-                    <p>foo</p>
-                  </BaseLayout>
-                }
-              />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route
+              path="/models"
+              element={
+                <BaseLayout>
+                  <p>foo</p>
+                </BaseLayout>
+              }
+            />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -118,18 +108,16 @@ describe("Base Layout", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/models/"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route
-                path="/models"
-                element={
-                  <BaseLayout>
-                    <p>foo</p>
-                  </BaseLayout>
-                }
-              />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route
+              path="/models"
+              element={
+                <BaseLayout>
+                  <p>foo</p>
+                </BaseLayout>
+              }
+            />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );

--- a/src/pages/ControllersIndex/ControllersIndex.test.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.test.tsx
@@ -2,8 +2,6 @@ import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
 import configureStore from "redux-mock-store";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import type { RootState } from "store/store";
 import {
@@ -28,9 +26,7 @@ describe("Controllers table", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ControllersIndex />
-          </QueryParamProvider>
+          <ControllersIndex />
         </Provider>
       </MemoryRouter>
     );
@@ -50,9 +46,7 @@ describe("Controllers table", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ControllersIndex />
-          </QueryParamProvider>
+          <ControllersIndex />
         </Provider>
       </MemoryRouter>
     );
@@ -73,9 +67,7 @@ describe("Controllers table", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ControllersIndex />
-          </QueryParamProvider>
+          <ControllersIndex />
         </Provider>
       </MemoryRouter>
     );
@@ -89,9 +81,7 @@ describe("Controllers table", () => {
         <MemoryRouter
           initialEntries={["/controllers?panel=register-controller"]}
         >
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ControllersIndex />
-          </QueryParamProvider>
+          <ControllersIndex />
         </MemoryRouter>
       </Provider>
     );
@@ -126,9 +116,7 @@ describe("Controllers table", () => {
     render(
       <MemoryRouter>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ControllersIndex />
-          </QueryParamProvider>
+          <ControllersIndex />
         </Provider>
       </MemoryRouter>
     );

--- a/src/pages/ControllersIndex/ControllersIndex.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.tsx
@@ -6,13 +6,13 @@ import {
 import FadeIn from "animations/FadeIn";
 import cloneDeep from "clone-deep";
 import Header from "components/Header/Header";
+import { useQueryParams } from "hooks/useQueryParams";
 import useWindowTitle from "hooks/useWindowTitle";
 import BaseLayout from "layout/BaseLayout/BaseLayout";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import { getControllerData, getModelData } from "store/juju/selectors";
 import { AdditionalController, Controller } from "store/juju/types";
-import { StringParam, useQueryParam } from "use-query-params";
 import ControllersOverview from "./ControllerOverview/ControllerOverview";
 import "./_controllers.scss";
 
@@ -173,7 +173,9 @@ function Details() {
 
   const rows = controllerMap && Object.values(controllerMap).map(generateRow);
 
-  const setPanelQs = useQueryParam("panel", StringParam)[1];
+  const [, setPanelQs] = useQueryParams<{ panel: string | null }>({
+    panel: null,
+  });
 
   return (
     <>
@@ -184,7 +186,7 @@ function Details() {
         <div className="controllers--register">
           <button
             className="p-button--positive"
-            onClick={() => setPanelQs("register-controller")}
+            onClick={() => setPanelQs({ panel: "register-controller" })}
           >
             Register a controller
           </button>

--- a/src/pages/EntityDetails/App/App.test.tsx
+++ b/src/pages/EntityDetails/App/App.test.tsx
@@ -3,8 +3,6 @@ import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import { TestId as InfoPanelTestId } from "components/InfoPanel/InfoPanel";
 import { RootState } from "store/store";
@@ -88,16 +86,14 @@ describe("Entity Details App", () => {
     render(
       <Provider store={store}>
         <BrowserRouter>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route
-                path="/models/:userName/:modelName/app/:appName"
-                element={<App />}
-              />
-              {/* Capture other paths to prevent warnings when navigating in the tests. */}
-              <Route path="*" element={<span />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route
+              path="/models/:userName/:modelName/app/:appName"
+              element={<App />}
+            />
+            {/* Capture other paths to prevent warnings when navigating in the tests. */}
+            <Route path="*" element={<span />} />
+          </Routes>
         </BrowserRouter>
       </Provider>
     );
@@ -197,9 +193,7 @@ describe("Entity Details App", () => {
     const secondInput = screen.getByTestId("table-checkbox-1");
     await userEvent.click(secondInput);
 
-    expect(window.location.search).toEqual(
-      "?panel=execute-action&units=0&units=1"
-    );
+    expect(window.location.search).toEqual("?panel=execute-action&units=0%2C1");
   });
 
   it("navigates to the actions log when button pressed", async () => {

--- a/src/pages/EntityDetails/EntityDetails.test.tsx
+++ b/src/pages/EntityDetails/EntityDetails.test.tsx
@@ -9,8 +9,6 @@ import { ReactNode } from "react";
 import { Provider } from "react-redux";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import { RootState } from "store/store";
 import { jujuStateFactory, rootStateFactory } from "testing/factories";
@@ -60,13 +58,11 @@ describe("Entity Details Container", () => {
     render(
       <Provider store={store}>
         <BrowserRouter>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path={urlPattern} element={<EntityDetails />}>
-                {props?.children}
-              </Route>
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path={urlPattern} element={<EntityDetails />}>
+              {props?.children}
+            </Route>
+          </Routes>
         </BrowserRouter>
       </Provider>
     );

--- a/src/pages/EntityDetails/EntityDetails.tsx
+++ b/src/pages/EntityDetails/EntityDetails.tsx
@@ -3,8 +3,8 @@ import classNames from "classnames";
 import { Spinner, Tabs } from "@canonical/react-components";
 import { useSelector, useStore } from "react-redux";
 import { useParams, Link, Outlet } from "react-router-dom";
-import { useQueryParams, StringParam, withDefault } from "use-query-params";
 
+import { useQueryParams } from "hooks/useQueryParams";
 import BaseLayout from "layout/BaseLayout/BaseLayout";
 
 import Breadcrumb from "components/Breadcrumb/Breadcrumb";
@@ -69,10 +69,10 @@ const EntityDetails = () => {
   const { isNestedEntityPage } = useEntityDetailsParams();
 
   const [query, setQuery] = useQueryParams({
-    panel: StringParam,
-    entity: StringParam,
-    activeView: withDefault(StringParam, "apps"),
-    filterQuery: withDefault(StringParam, ""),
+    panel: null,
+    entity: null,
+    activeView: "apps",
+    filterQuery: "",
   });
   const setActiveView = (view?: string) => {
     setQuery({ activeView: view });

--- a/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.test.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.test.tsx
@@ -7,8 +7,7 @@ import { jujuStateFactory, rootStateFactory } from "testing/factories";
 import { generalStateFactory } from "testing/factories/general";
 import { charmApplicationFactory } from "testing/factories/juju/Charms";
 import { modelWatcherModelDataFactory } from "testing/factories/juju/model-watcher";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
+
 import ApplicationsTab from "./ApplicationsTab";
 
 const mockStore = configureStore([]);
@@ -97,14 +96,12 @@ describe("ApplicationsTab", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/models/test@external/test-model"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route
-                path="/models/:userName/:modelName"
-                element={<ApplicationsTab filterQuery={filterQuery} />}
-              />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route
+              path="/models/:userName/:modelName"
+              element={<ApplicationsTab filterQuery={filterQuery} />}
+            />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );

--- a/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.tsx
@@ -3,12 +3,6 @@ import Fuse from "fuse.js";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
-import {
-  StringParam,
-  useQueryParam,
-  useQueryParams,
-  withDefault,
-} from "use-query-params";
 
 import {
   appsOffersTableHeaders,
@@ -30,6 +24,7 @@ import classnames from "classnames";
 import { EntityDetailsRoute } from "components/Routes/Routes";
 import useAnalytics from "hooks/useAnalytics";
 import useModelStatus from "hooks/useModelStatus";
+import { useQueryParams } from "hooks/useQueryParams";
 import useTableRowClick from "hooks/useTableRowClick";
 import { getCharmsFromApplications } from "juju/api";
 import { ApplicationData, ApplicationInfo } from "juju/types";
@@ -74,7 +69,9 @@ function SearchResultsActionsRow() {
   const { userName, modelName } = useParams<EntityDetailsRoute>();
   const modelUUID = useSelector(getModelUUIDFromList(modelName, userName));
 
-  const [, setPanel] = useQueryParam("panel", StringParam);
+  const [, setPanel] = useQueryParams<{ panel: string | null }>({
+    panel: null,
+  });
 
   const handleRunAction = async () => {
     sendAnalytics({
@@ -87,7 +84,7 @@ function SearchResultsActionsRow() {
       appState,
       dispatch
     );
-    setPanel("choose-charm");
+    setPanel({ panel: "choose-charm" });
   };
 
   return (
@@ -112,10 +109,14 @@ type Props = {
 
 export default function ApplicationsTab({ filterQuery }: Props) {
   const navigate = useNavigate();
-  const [queryParams, setQueryParams] = useQueryParams({
-    panel: StringParam,
-    entity: StringParam,
-    activeView: withDefault(StringParam, "apps"),
+  const [queryParams, setQueryParams] = useQueryParams<{
+    entity: string | null;
+    panel: string | null;
+    activeView: string;
+  }>({
+    panel: null,
+    entity: null,
+    activeView: "apps",
   });
   const { userName, modelName } = useParams<EntityDetailsRoute>();
 

--- a/src/pages/EntityDetails/Model/Model.test.tsx
+++ b/src/pages/EntityDetails/Model/Model.test.tsx
@@ -2,8 +2,6 @@ import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import { TestId } from "components/InfoPanel/InfoPanel";
 import { RootState } from "store/store";
@@ -110,11 +108,9 @@ describe("Model", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/models/eggman@external/test1"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -133,11 +129,9 @@ describe("Model", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/models/eggman@external/test1"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -164,11 +158,9 @@ describe("Model", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/models/eggman@external/test1"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -213,11 +205,9 @@ describe("Model", () => {
         <MemoryRouter
           initialEntries={["/models/eggman@external/test1?activeView=apps"]}
         >
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -262,11 +252,9 @@ describe("Model", () => {
         <MemoryRouter
           initialEntries={["/models/eggman@external/test1?activeView=machines"]}
         >
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -313,11 +301,9 @@ describe("Model", () => {
             "/models/eggman@external/test1?activeView=integrations",
           ]}
         >
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -364,11 +350,9 @@ describe("Model", () => {
             "/models/eggman@external/test1?activeView=action-logs",
           ]}
         >
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -405,11 +389,9 @@ describe("Model", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/models/eggman@external/test1"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -432,11 +414,9 @@ describe("Model", () => {
         <MemoryRouter
           initialEntries={["/models/eggman@external/test1?activeView=machines"]}
         >
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -460,11 +440,9 @@ describe("Model", () => {
       <Provider store={store}>
         cockroachdb
         <MemoryRouter initialEntries={["/models/eggman@external/test1"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -493,11 +471,9 @@ describe("Model", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/models/eggman@external/test1"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -519,11 +495,9 @@ describe("Model", () => {
             "/models/eggman@external/test1?activeView=integrations",
           ]}
         >
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -544,11 +518,9 @@ describe("Model", () => {
         <MemoryRouter
           initialEntries={["/models/eggman@external/test1?activeView=machines"]}
         >
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -589,11 +561,9 @@ describe("Model", () => {
         <MemoryRouter
           initialEntries={["/models/eggman@external/test1?activeView=machines"]}
         >
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -638,11 +608,9 @@ describe("Model", () => {
         <MemoryRouter
           initialEntries={["/models/eggman@external/test1?activeView=machines"]}
         >
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -675,11 +643,9 @@ describe("Model", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/models/eggman@external/test1"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );
@@ -704,11 +670,9 @@ describe("Model", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/models/eggman@external/test1"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route path="/models/:userName/:modelName" element={<Model />} />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route path="/models/:userName/:modelName" element={<Model />} />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );

--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -6,12 +6,6 @@ import {
   canAdministerModelAccess,
   extractCloudName,
 } from "store/juju/utils/models";
-import {
-  StringParam,
-  useQueryParam,
-  useQueryParams,
-  withDefault,
-} from "use-query-params";
 
 import {
   consumedTableHeaders,
@@ -33,6 +27,7 @@ import EntityInfo from "components/EntityInfo/EntityInfo";
 import ActionLogs from "pages/EntityDetails/Model/ActionLogs/ActionLogs";
 
 import useModelStatus from "hooks/useModelStatus";
+import { useQueryParams } from "hooks/useQueryParams";
 import useTableRowClick from "hooks/useTableRowClick";
 
 import {
@@ -85,11 +80,16 @@ const Model = () => {
 
   const { userName, modelName } = useParams<EntityDetailsRoute>();
 
-  const [query] = useQueryParams({
-    panel: StringParam,
-    entity: StringParam,
-    activeView: withDefault(StringParam, "apps"),
-    filterQuery: withDefault(StringParam, ""),
+  const [query, setQuery] = useQueryParams<{
+    entity: string | null;
+    panel: string | null;
+    activeView: string;
+    filterQuery: string;
+  }>({
+    panel: null,
+    entity: null,
+    activeView: "apps",
+    filterQuery: "",
   });
 
   const tableRowClick = useTableRowClick();
@@ -123,7 +123,6 @@ const Model = () => {
     getModelAccess(state, modelUUID)
   );
 
-  const setPanelQs = useQueryParam("panel", StringParam)[1];
   const [applicationsFilterQuery, setApplicationsFilterQuery] =
     useState<string>(query.filterQuery || "");
 
@@ -146,7 +145,7 @@ const Model = () => {
             ) && (
               <button
                 className="entity-details__action-button"
-                onClick={() => setPanelQs("share-model")}
+                onClick={() => setQuery({ panel: "share-model" })}
               >
                 <i className="p-icon--share"></i>
                 {Label.ACCESS_BUTTON}

--- a/src/pages/ModelsIndex/ModelsIndex.test.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.test.tsx
@@ -3,8 +3,6 @@ import { Provider } from "react-redux";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { BrowserRouter, MemoryRouter } from "react-router-dom";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import { rootStateFactory } from "testing/factories/root";
 import { RootState } from "store/store";
@@ -68,9 +66,7 @@ describe("Models Index page", () => {
     render(
       <Provider store={store}>
         <MemoryRouter>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ModelsIndex />
-          </QueryParamProvider>
+          <ModelsIndex />
         </MemoryRouter>
       </Provider>
     );
@@ -85,9 +81,7 @@ describe("Models Index page", () => {
     render(
       <Provider store={store}>
         <MemoryRouter>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ModelsIndex />
-          </QueryParamProvider>
+          <ModelsIndex />
         </MemoryRouter>
       </Provider>
     );
@@ -100,9 +94,7 @@ describe("Models Index page", () => {
     render(
       <Provider store={store}>
         <MemoryRouter>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ModelsIndex />
-          </QueryParamProvider>
+          <ModelsIndex />
         </MemoryRouter>
       </Provider>
     );
@@ -116,9 +108,7 @@ describe("Models Index page", () => {
     render(
       <Provider store={store}>
         <BrowserRouter>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ModelsIndex />
-          </QueryParamProvider>
+          <ModelsIndex />
         </BrowserRouter>
       </Provider>
     );
@@ -139,9 +129,7 @@ describe("Models Index page", () => {
     render(
       <Provider store={store}>
         <BrowserRouter>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <ModelsIndex />
-          </QueryParamProvider>
+          <ModelsIndex />
         </BrowserRouter>
       </Provider>
     );

--- a/src/pages/ModelsIndex/ModelsIndex.tsx
+++ b/src/pages/ModelsIndex/ModelsIndex.tsx
@@ -8,23 +8,11 @@ import ChipGroup from "components/ChipGroup/ChipGroup";
 import Header from "components/Header/Header";
 import ModelTableList from "components/ModelTableList/ModelTableList";
 import BaseLayout from "layout/BaseLayout/BaseLayout";
-
 import useModelAttributes from "hooks/useModelAttributes";
-
+import { useQueryParams } from "hooks/useQueryParams";
 import useWindowTitle from "hooks/useWindowTitle";
-
 import FadeIn from "animations/FadeIn";
-
 import { pluralize } from "store/juju/utils/models";
-
-import {
-  ArrayParam,
-  StringParam,
-  useQueryParam,
-  useQueryParams,
-  withDefault,
-} from "use-query-params";
-
 import {
   getGroupedModelStatusCounts,
   getModelData,
@@ -45,19 +33,29 @@ export enum TestId {
 
 export default function Models() {
   useWindowTitle("Models");
-  // Grab filter from 'groupedby' query in URL and assign to variable
-  const [groupModelsBy, setGroupModelsBy] = useQueryParam(
-    "groupedby",
-    withDefault(StringParam, "status")
-  );
 
-  const [filters, setFilters] = useQueryParams({
-    cloud: withDefault(ArrayParam, []),
-    owner: withDefault(ArrayParam, []),
-    region: withDefault(ArrayParam, []),
-    credential: withDefault(ArrayParam, []),
-    custom: withDefault(ArrayParam, []),
+  const [queryParams, setQueryParams] = useQueryParams<{
+    groupedby: string;
+    cloud: string[];
+    owner: string[];
+    region: string[];
+    credential: string[];
+    custom: string[];
+  }>({
+    groupedby: "status",
+    cloud: [],
+    owner: [],
+    region: [],
+    credential: [],
+    custom: [],
   });
+  const filters = {
+    cloud: queryParams.cloud,
+    owner: queryParams.owner,
+    region: queryParams.region,
+    credential: queryParams.credential,
+    custom: queryParams.custom,
+  };
 
   const modelsLoaded = useAppSelector(getModelListLoaded);
   const hasSomeModels = useSelector(hasModels);
@@ -127,7 +125,10 @@ export default function Models() {
         <div className="l-content">
           <div className="models">
             <ChipGroup chips={{ blocked, alert, running }} />
-            <ModelTableList groupedBy={groupModelsBy} filters={filters} />
+            <ModelTableList
+              groupedBy={queryParams.groupedby}
+              filters={filters}
+            />
           </div>
         </div>
       </FadeIn>
@@ -142,11 +143,11 @@ export default function Models() {
             {modelCount} {pluralize(modelCount, "model")}
           </strong>
           <ButtonGroup
-            activeButton={groupModelsBy}
+            activeButton={queryParams.groupedby}
             buttons={["status", "cloud", "owner"]}
             label="Group by:"
             noWrap
-            setActiveButton={setGroupModelsBy}
+            setActiveButton={(group) => setQueryParams({ groupedby: group })}
           />
           <SearchAndFilter
             filterPanelData={[
@@ -193,7 +194,7 @@ export default function Models() {
                 });
 
               if (!isObjectsEqual(activeFilters, filters)) {
-                setFilters(activeFilters);
+                setQueryParams(activeFilters);
               }
             }}
           />

--- a/src/pages/PageNotFound/PageNotFound.test.tsx
+++ b/src/pages/PageNotFound/PageNotFound.test.tsx
@@ -2,8 +2,6 @@ import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import { rootStateFactory } from "testing/factories/root";
 
@@ -19,9 +17,7 @@ describe("PageNotFound page", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/foobar11"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes />
-          </QueryParamProvider>
+          <Routes />
         </MemoryRouter>
       </Provider>
     );

--- a/src/panels/ActionsPanel/ActionsPanel.test.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.test.tsx
@@ -3,8 +3,7 @@ import configureStore from "redux-mock-store";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
+
 import { InitialEntry } from "@remix-run/router";
 import * as juju from "juju/api";
 
@@ -72,21 +71,19 @@ describe("ActionsPanel", () => {
   function generateComponent(initialEntries?: InitialEntry[]) {
     if (!initialEntries) {
       initialEntries = [
-        "/models/user-eggman@external/group-test/app/kubernetes-master?panel=execute-action&units=ceph%2F0&units=ceph%2F1",
+        "/models/user-eggman@external/group-test/app/kubernetes-master?panel=execute-action&units=ceph%2F0,ceph%2F1",
       ];
     }
     const store = mockStore(state);
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={initialEntries}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route
-                path="/models/:userName/:modelName/app/:appName"
-                element={<ActionsPanel />}
-              />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route
+              path="/models/:userName/:modelName/app/:appName"
+              element={<ActionsPanel />}
+            />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );

--- a/src/panels/ActionsPanel/ActionsPanel.tsx
+++ b/src/panels/ActionsPanel/ActionsPanel.tsx
@@ -13,7 +13,6 @@ import {
 } from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
-import { ArrayParam, useQueryParam, withDefault } from "use-query-params";
 
 import type { EntityDetailsRoute } from "components/Routes/Routes";
 
@@ -22,6 +21,7 @@ import ConfirmationModal from "components/ConfirmationModal/ConfirmationModal";
 import LoadingHandler from "components/LoadingHandler/LoadingHandler";
 import PanelHeader from "components/PanelHeader/PanelHeader";
 import RadioInputBox from "components/RadioInputBox/RadioInputBox";
+import { useQueryParams } from "hooks/useQueryParams";
 import { RootState, useAppStore } from "store/store";
 
 import ActionOptions from "./ActionOptions";
@@ -100,13 +100,11 @@ export default function ActionsPanel(): JSX.Element {
 
   const actionOptionsValues = useRef<ActionOptionValues>({});
 
-  const selectedUnits = useQueryParam(
-    "units",
-    withDefault(ArrayParam, [])
-    // Cast it into an array so it has the proper methods for the reduce below.
-  )[0] as string[];
-
-  const closePanel = useQueryParam("panel")[1];
+  const [queryParams, setQueryParams] = useQueryParams<{
+    units: string[];
+    panel: string | null;
+  }>({ units: [], panel: null });
+  const selectedUnits = queryParams.units;
 
   useEffect(() => {
     setFetchingActionData(true);
@@ -202,7 +200,7 @@ export default function ActionsPanel(): JSX.Element {
           () => {
             setConfirmType("");
             executeAction();
-            closePanel("");
+            setQueryParams(null);
           },
           () => setConfirmType("")
         );

--- a/src/panels/ActionsPanel/CharmActionsPanel.tsx
+++ b/src/panels/ActionsPanel/CharmActionsPanel.tsx
@@ -9,7 +9,6 @@ import {
 } from "react";
 import reactHotToast from "react-hot-toast";
 import { useSelector } from "react-redux";
-import { StringParam, useQueryParam, useQueryParams } from "use-query-params";
 
 import Aside from "components/Aside/Aside";
 import ConfirmationModal from "components/ConfirmationModal/ConfirmationModal";
@@ -21,6 +20,7 @@ import LoadingHandler from "components/LoadingHandler/LoadingHandler";
 import ToastCard from "components/ToastCard/ToastCard";
 import { generateIconImg } from "components/utils";
 import useAnalytics from "hooks/useAnalytics";
+import { useQueryParams } from "hooks/useQueryParams";
 import { executeActionOnUnits } from "juju/api";
 import { ApplicationInfo } from "juju/types";
 import ActionOptions from "panels/ActionsPanel/ActionOptions";
@@ -51,8 +51,9 @@ export default function CharmActionsPanel(): JSX.Element {
   const [confirmType, setConfirmType] = useState<string>("");
   const [selectedAction, setSelectedAction] = useState<string>();
   const actionOptionsValues = useRef<ActionOptionValues>({});
-  const [queryParams] = useQueryParams({
-    charm: StringParam,
+  const [queryParams, setQueryParams] = useQueryParams({
+    charm: null,
+    panel: null,
   });
   const selectedApplications = useSelector(
     getSelectedApplications(queryParams.charm || "")
@@ -62,7 +63,6 @@ export default function CharmActionsPanel(): JSX.Element {
     () => selectedCharm?.actions?.specs || {},
     [selectedCharm]
   );
-  const closePanel = useQueryParam("panel")[1];
   const generateTitle = () => {
     if (!selectedApplications || !selectedCharm)
       return "You need to select a charm and applications to continue.";
@@ -167,7 +167,7 @@ export default function CharmActionsPanel(): JSX.Element {
           () => {
             setConfirmType("");
             executeAction();
-            closePanel("");
+            setQueryParams({ panel: null });
           },
           () => setConfirmType("")
         );

--- a/src/panels/CharmsPanel/ChamsPanel.tsx
+++ b/src/panels/CharmsPanel/ChamsPanel.tsx
@@ -1,16 +1,19 @@
 import { Button, RadioInput } from "@canonical/react-components";
 import Aside from "components/Aside/Aside";
 import PanelHeader from "components/PanelHeader/PanelHeader";
+import { useQueryParams } from "hooks/useQueryParams";
 import { FormEventHandler, useState } from "react";
 import { useSelector } from "react-redux";
 import { getCharms } from "store/juju/selectors";
-import { StringParam, useQueryParams } from "use-query-params";
 import "./_charms-panel.scss";
 
 export default function CharmsPanel() {
-  const [, setQuery] = useQueryParams({
-    panel: StringParam,
-    charm: StringParam,
+  const [, setQuery] = useQueryParams<{
+    panel: string | null;
+    charm: string | null;
+  }>({
+    panel: null,
+    charm: null,
   });
 
   const [selectedCharm, setSelectedCharm] = useState<string | null>(null);

--- a/src/panels/CharmsPanel/CharmsPanel.test.tsx
+++ b/src/panels/CharmsPanel/CharmsPanel.test.tsx
@@ -9,8 +9,7 @@ import {
   charmApplicationFactory,
   charmInfoFactory,
 } from "testing/factories/juju/Charms";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
+
 import CharmsPanel from "./ChamsPanel";
 
 const mockStore = configureStore([]);
@@ -45,14 +44,12 @@ describe("CharmsPanel", () => {
         <MemoryRouter
           initialEntries={["/models/admin/tests?panel=choose-charm"]}
         >
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route
-                path="/models/:userName/:modelName"
-                element={<CharmsPanel />}
-              />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route
+              path="/models/:userName/:modelName"
+              element={<CharmsPanel />}
+            />
+          </Routes>
         </MemoryRouter>
       </Provider>
     );

--- a/src/panels/ShareModelPanel/ShareModel.test.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.test.tsx
@@ -3,8 +3,7 @@ import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
+
 import { actions as appActions } from "store/app";
 
 import { Label } from "components/ShareCard/ShareCard";
@@ -55,14 +54,12 @@ describe("Share Model Panel", () => {
     render(
       <MemoryRouter initialEntries={["/models/eggman@external/hadoopspark"]}>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route
-                path="/models/:userName/:modelName"
-                element={<ShareModel />}
-              />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route
+              path="/models/:userName/:modelName"
+              element={<ShareModel />}
+            />
+          </Routes>
         </Provider>
       </MemoryRouter>
     );
@@ -76,14 +73,12 @@ describe("Share Model Panel", () => {
     render(
       <MemoryRouter initialEntries={["/models/eggman@external/hadoopspark"]}>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route
-                path="/models/:userName/:modelName"
-                element={<ShareModel />}
-              />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route
+              path="/models/:userName/:modelName"
+              element={<ShareModel />}
+            />
+          </Routes>
         </Provider>
       </MemoryRouter>
     );
@@ -104,14 +99,12 @@ describe("Share Model Panel", () => {
     render(
       <MemoryRouter initialEntries={["/models/eggman@external/hadoopspark"]}>
         <Provider store={store}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Routes>
-              <Route
-                path="/models/:userName/:modelName"
-                element={<ShareModel />}
-              />
-            </Routes>
-          </QueryParamProvider>
+          <Routes>
+            <Route
+              path="/models/:userName/:modelName"
+              element={<ShareModel />}
+            />
+          </Routes>
         </Provider>
       </MemoryRouter>
     );

--- a/src/panels/panels.test.tsx
+++ b/src/panels/panels.test.tsx
@@ -1,9 +1,7 @@
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import { QueryParamProvider } from "use-query-params";
-import { ReactRouter6Adapter } from "use-query-params/adapters/react-router-6";
 
 import { rootStateFactory } from "testing/factories/root";
 
@@ -18,9 +16,7 @@ describe("Panels", () => {
     render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/foo"]}>
-          <QueryParamProvider adapter={ReactRouter6Adapter}>
-            <Panels />
-          </QueryParamProvider>
+          <Panels />
         </MemoryRouter>
       </Provider>,
       {
@@ -33,9 +29,11 @@ describe("Panels", () => {
 
     const closeSpy = jest.spyOn(close, "onEscape");
 
-    outerNode.dispatchEvent(
-      new KeyboardEvent("keydown", { code: "Escape", bubbles: true })
-    );
+    act(() => {
+      outerNode.dispatchEvent(
+        new KeyboardEvent("keydown", { code: "Escape", bubbles: true })
+      );
+    });
     expect(closeSpy).toHaveBeenCalled();
   });
 });

--- a/src/panels/panels.tsx
+++ b/src/panels/panels.tsx
@@ -1,6 +1,6 @@
 import { useListener } from "@canonical/react-components";
 import { AnimatePresence } from "framer-motion";
-import { StringParam, useQueryParam } from "use-query-params";
+import { useQueryParams } from "hooks/useQueryParams";
 
 import ActionsPanel from "panels/ActionsPanel/ActionsPanel";
 import RegisterController from "panels/RegisterController/RegisterController";
@@ -23,16 +23,18 @@ export const close = {
 };
 
 export default function Panels() {
-  const [panelQs, setPanelQs] = useQueryParam("panel", StringParam);
+  const [panelQs, setPanelQs] = useQueryParams<{ panel: string | null }>({
+    panel: null,
+  });
 
   useListener(
     window,
-    (e: KeyboardEvent) => close.onEscape(e, setPanelQs),
+    (e: KeyboardEvent) => close.onEscape(e, () => setPanelQs(null)),
     "keydown"
   );
 
   const generatePanel = () => {
-    switch (panelQs) {
+    switch (panelQs.panel) {
       case "register-controller":
         return <RegisterController />;
       case "execute-action":
@@ -47,5 +49,5 @@ export default function Panels() {
         return null;
     }
   };
-  return <AnimatePresence>{panelQs && generatePanel()}</AnimatePresence>;
+  return <AnimatePresence>{panelQs.panel && generatePanel()}</AnimatePresence>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9444,11 +9444,6 @@ serialize-javascript@^6.0.0:
   dependencies:
     randombytes "^2.1.0"
 
-serialize-query-params@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-2.0.2.tgz#598a3fb9e13f4ea1c1992fbd20231aa16b31db81"
-  integrity sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q==
-
 serve-index@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
@@ -10442,13 +10437,6 @@ url-parse@^1.5.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-use-query-params@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-2.1.2.tgz#0bd100a0839e5195106cfb291b43d2159618ca9d"
-  integrity sha512-evg64srKaILvKyRQ1zpXvekTC7rktAT7OAekU7x6naHrOMqLHtq0MHR/PtKIQAP4d7HrkYNVOS8exHhiWy7m3A==
-  dependencies:
-    serialize-query-params "^2.0.2"
 
 use-ssr@^1.0.22:
   version "1.0.24"


### PR DESCRIPTION
## Done

- Replace use-query-params with the hook from React Router.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Check that you can filter the model list.
- Check that you can filter applications in a model.
- Check that the access, config, actions etc. panels open and close.

## Details

https://warthogs.atlassian.net/browse/WD-2883