### PR TITLE
WD-2910 - Display model access

### DIFF
--- a/src/pages/EntityDetails/Model/Model.tsx
+++ b/src/pages/EntityDetails/Model/Model.tsx
@@ -37,6 +37,7 @@ import useTableRowClick from "hooks/useTableRowClick";
 
 import {
   getActiveUser,
+  getModelAccess,
   getModelApplications,
   getModelInfo,
   getModelMachines,
@@ -118,6 +119,9 @@ const Model = () => {
   );
 
   const modelInfoData = useSelector(getModelInfo(modelUUID));
+  const modelAccess = useAppSelector((state) =>
+    getModelAccess(state, modelUUID)
+  );
 
   const setPanelQs = useQueryParam("panel", StringParam)[1];
   const [applicationsFilterQuery, setApplicationsFilterQuery] =
@@ -148,6 +152,7 @@ const Model = () => {
         {modelInfoData && (
           <EntityInfo
             data={{
+              access: modelAccess ?? "Unknown",
               controller: modelInfoData.type,
               "Cloud/Region": generateCloudAndRegion(
                 modelInfoData["cloud-tag"],

--- a/src/store/general/selectors.test.ts
+++ b/src/store/general/selectors.test.ts
@@ -17,6 +17,7 @@ import {
   getWSControllerURL,
   isConnecting,
   isLoggedIn,
+  getActiveUserControllerAccess,
 } from "./selectors";
 
 describe("selectors", () => {
@@ -148,6 +149,25 @@ describe("selectors", () => {
         "wss://example.com"
       )
     ).toBe("user");
+  });
+
+  it("getActiveUserControllerAccess", () => {
+    expect(
+      getActiveUserControllerAccess(
+        rootStateFactory.build({
+          general: generalStateFactory.build({
+            controllerConnections: {
+              "wss://example.com": {
+                user: {
+                  "controller-access": "superuser",
+                },
+              },
+            },
+          }),
+        }),
+        "wss://example.com"
+      )
+    ).toBe("superuser");
   });
 
   it("isLoggedIn", () => {

--- a/src/store/general/selectors.ts
+++ b/src/store/general/selectors.ts
@@ -72,6 +72,7 @@ export const isConnecting = createSelector(
   [slice],
   (sliceState) => !!sliceState?.visitURL
 );
+
 /**
     Returns the users current controller logged in identity
     @param wsControllerURL The controller url to make the query on.
@@ -86,6 +87,16 @@ export const getActiveUserTag = createSelector(
   (_sliceState, controllerConnection) =>
     // TSFixMe: jujulib types user as `object`.
     (controllerConnection?.user as TSFixMe)?.identity
+);
+
+export const getActiveUserControllerAccess = createSelector(
+  [
+    slice,
+    (state, wsControllerURL) => getControllerConnection(state, wsControllerURL),
+  ],
+  (_sliceState, controllerConnection) =>
+    // TSFixMe: jujulib types user as `object`.
+    (controllerConnection?.user as TSFixMe)?.["controller-access"]
 );
 
 /**


### PR DESCRIPTION
## Done

- Display model access level on the model details page.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Go to the model details page for a model that you have been explicitly granted access to and you should see the correct access level in the sidebar.
- Go to a model where you haven't been granted access but you're a controller superuser and you should see "superuser" in the sidebar.

## Details

Fixes: #710.
https://warthogs.atlassian.net/browse/WD-2910

## Screenshots

<img width="309" alt="Screenshot 2023-03-29 at 2 44 48 pm" src="https://user-images.githubusercontent.com/361637/228426327-486082c8-ca09-44aa-9941-675c8e51d27d.png">

