### PR TITLE
WD-2929 - Add help for usernames

### DIFF
--- a/src/panels/ShareModelPanel/ShareModel.test.tsx
+++ b/src/panels/ShareModelPanel/ShareModel.test.tsx
@@ -41,7 +41,10 @@ describe("Share Model Panel", () => {
             info: modelDataInfoFactory.build({
               "controller-uuid": "123",
               name: "hadoopspark",
-              users: [modelUserInfoFactory.build()],
+              users: [
+                modelUserInfoFactory.build({ user: "eggman@external" }),
+                modelUserInfoFactory.build({ user: "spaceman@domain" }),
+              ],
             }),
           }),
         },
@@ -66,6 +69,86 @@ describe("Share Model Panel", () => {
     expect(
       screen.getByRole("heading", { name: "Sharing with:" })
     ).toBeInTheDocument();
+  });
+
+  it("displays domain suggestions", async () => {
+    state.juju.modelData.def456 = modelDataFactory.build({
+      info: modelDataInfoFactory.build({
+        users: [
+          modelUserInfoFactory.build({ user: "other@model2" }),
+          modelUserInfoFactory.build({ user: "other2@anothermodel2" }),
+        ],
+      }),
+    });
+    const store = mockStore(state);
+    render(
+      <MemoryRouter initialEntries={["/models/eggman@external/hadoopspark"]}>
+        <Provider store={store}>
+          <Routes>
+            <Route
+              path="/models/:userName/:modelName"
+              element={<ShareModel />}
+            />
+          </Routes>
+        </Provider>
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole("button", { name: "@external" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "@domain" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "@model2" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "@anothermodel2" })
+    ).toBeInTheDocument();
+  });
+
+  it("can insert a domain", async () => {
+    const store = mockStore(state);
+    render(
+      <MemoryRouter initialEntries={["/models/eggman@external/hadoopspark"]}>
+        <Provider store={store}>
+          <Routes>
+            <Route
+              path="/models/:userName/:modelName"
+              element={<ShareModel />}
+            />
+          </Routes>
+        </Provider>
+      </MemoryRouter>
+    );
+    await userEvent.type(
+      screen.getByRole("textbox", { name: "Username" }),
+      "eggman"
+    );
+    await userEvent.click(screen.getByRole("button", { name: "@external" }));
+    expect(screen.getByRole("textbox", { name: "Username" })).toHaveValue(
+      "eggman@external"
+    );
+  });
+
+  it("can replace a domain", async () => {
+    const store = mockStore(state);
+    render(
+      <MemoryRouter initialEntries={["/models/eggman@external/hadoopspark"]}>
+        <Provider store={store}>
+          <Routes>
+            <Route
+              path="/models/:userName/:modelName"
+              element={<ShareModel />}
+            />
+          </Routes>
+        </Provider>
+      </MemoryRouter>
+    );
+    await userEvent.type(
+      screen.getByRole("textbox", { name: "Username" }),
+      "eggman@otherdomain"
+    );
+    await userEvent.click(screen.getByRole("button", { name: "@external" }));
+    expect(screen.getByRole("textbox", { name: "Username" })).toHaveValue(
+      "eggman@external"
+    );
   });
 
   it("should show small screen view toggles", async () => {
@@ -118,7 +201,7 @@ describe("Share Model Panel", () => {
       modelUUID: "84e872ff-9171-46be-829b-70f0ffake18d",
       permissionFrom: "read",
       permissionTo: undefined,
-      user: "user-eggman@external",
+      user: "spaceman@domain",
       wsControllerURL: "wss://jimm.jujucharms.com/api",
     });
   });

--- a/src/store/juju/selectors.test.ts
+++ b/src/store/juju/selectors.test.ts
@@ -38,6 +38,10 @@ import {
   getModelDataByUUID,
   getModelAccess,
   getFilteredModelData,
+  getExternalUsers,
+  getExternalUsersInModel,
+  getUserDomains,
+  getUserDomainsInModel,
 } from "./selectors";
 import { modelUserInfoFactory } from "../../testing/factories/juju/juju";
 
@@ -503,6 +507,125 @@ describe("selectors", () => {
       abc123: "eggman@external",
       def456: "spaceman@external",
     });
+  });
+
+  it("getExternalUsers", () => {
+    const state = rootStateFactory.build({
+      juju: jujuStateFactory.build({
+        modelData: {
+          abc123: modelDataFactory.build({
+            info: modelDataInfoFactory.build({
+              users: [
+                modelUserInfoFactory.build({ user: "eggman@external" }),
+                modelUserInfoFactory.build({ user: "spaceman@domain" }),
+                modelUserInfoFactory.build({ user: "frogman" }),
+              ],
+            }),
+          }),
+          def456: modelDataFactory.build({
+            info: modelDataInfoFactory.build({
+              users: [
+                modelUserInfoFactory.build({ user: "other@model2" }),
+                modelUserInfoFactory.build({ user: "other2@anothermodel2" }),
+                modelUserInfoFactory.build({ user: "other3" }),
+              ],
+            }),
+          }),
+        },
+      }),
+    });
+    expect(getExternalUsers(state)).toStrictEqual([
+      "eggman@external",
+      "spaceman@domain",
+      "other@model2",
+      "other2@anothermodel2",
+    ]);
+  });
+
+  it("getExternalUsersInModel", () => {
+    const state = rootStateFactory.build({
+      juju: jujuStateFactory.build({
+        modelData: {
+          abc123: modelDataFactory.build({
+            info: modelDataInfoFactory.build({
+              users: [
+                modelUserInfoFactory.build({ user: "eggman@external" }),
+                modelUserInfoFactory.build({ user: "spaceman@domain" }),
+                modelUserInfoFactory.build({ user: "frogman" }),
+              ],
+            }),
+          }),
+          def456: modelDataFactory.build({
+            info: modelDataInfoFactory.build({
+              users: [modelUserInfoFactory.build({ user: "other@model2" })],
+            }),
+          }),
+        },
+      }),
+    });
+    expect(getExternalUsersInModel(state, "abc123")).toStrictEqual([
+      "eggman@external",
+      "spaceman@domain",
+    ]);
+  });
+
+  it("getUserDomains", () => {
+    const state = rootStateFactory.build({
+      juju: jujuStateFactory.build({
+        modelData: {
+          abc123: modelDataFactory.build({
+            info: modelDataInfoFactory.build({
+              users: [
+                modelUserInfoFactory.build({ user: "eggman@external" }),
+                modelUserInfoFactory.build({ user: "spaceman@domain" }),
+                modelUserInfoFactory.build({ user: "frogman" }),
+              ],
+            }),
+          }),
+          def456: modelDataFactory.build({
+            info: modelDataInfoFactory.build({
+              users: [
+                modelUserInfoFactory.build({ user: "other@model2" }),
+                modelUserInfoFactory.build({ user: "other2@external" }),
+              ],
+            }),
+          }),
+        },
+      }),
+    });
+    expect(getUserDomains(state)).toStrictEqual([
+      "external",
+      "domain",
+      "model2",
+    ]);
+  });
+
+  it("getUserDomainsInModel", () => {
+    const state = rootStateFactory.build({
+      juju: jujuStateFactory.build({
+        modelData: {
+          abc123: modelDataFactory.build({
+            info: modelDataInfoFactory.build({
+              users: [
+                modelUserInfoFactory.build({ user: "eggman@external" }),
+                modelUserInfoFactory.build({ user: "spaceman@domain" }),
+                modelUserInfoFactory.build({ user: "frogman" }),
+                modelUserInfoFactory.build({ user: "fireman@external" }),
+              ],
+            }),
+          }),
+          def456: modelDataFactory.build({
+            info: modelDataInfoFactory.build({
+              users: [modelUserInfoFactory.build({ user: "other@model2" })],
+            }),
+          }),
+        },
+      }),
+    });
+    expect(getUserDomainsInModel(state, "abc123")).toStrictEqual([
+      "external",
+      "domain",
+    ]);
   });
 
   describe("getFilteredModelData", () => {

--- a/src/store/juju/selectors.ts
+++ b/src/store/juju/selectors.ts
@@ -74,8 +74,8 @@ export const getModelByUUID = createSelector(
 );
 
 export const getModelDataByUUID = createSelector(
-  [getModelData, (_, modelUUID: string) => modelUUID],
-  (modelData, modelUUID) => modelData[modelUUID]
+  [getModelData, (_, modelUUID?: string | null) => modelUUID],
+  (modelData, modelUUID) => (modelUUID ? modelData[modelUUID] : null)
 );
 
 /**
@@ -92,6 +92,62 @@ export const getActiveUsers = createSelector(
       )?.replace("user-", "");
     });
     return activeUsers;
+  }
+);
+
+/**
+  Get all unique external users.
+*/
+export const getExternalUsers = createSelector([getModelData], (models) => {
+  const users = new Set<string>();
+  Object.values(models).forEach((model) => {
+    model.info?.users.forEach(({ user }) => {
+      if (user.includes("@")) {
+        users.add(user);
+      }
+    });
+  });
+  return Array.from(users.values());
+});
+
+/**
+  Get external users in a mdoel.
+*/
+export const getExternalUsersInModel = createSelector(
+  [getModelDataByUUID],
+  (model) => {
+    const users = new Set<string>();
+    model?.info?.users.forEach(({ user }) => {
+      if (user.includes("@")) {
+        users.add(user);
+      }
+    });
+    return Array.from(users.values());
+  }
+);
+
+/**
+  Get user domains.
+*/
+export const getUserDomains = createSelector([getExternalUsers], (users) => {
+  const domains = new Set<string>();
+  users.forEach((user) => {
+    domains.add(user.split("@")[1]);
+  });
+  return Array.from(domains.values());
+});
+
+/**
+  Get user domains in a model.
+*/
+export const getUserDomainsInModel = createSelector(
+  [getExternalUsersInModel],
+  (users) => {
+    const domains = new Set<string>();
+    users.forEach((user) => {
+      domains.add(user.split("@")[1]);
+    });
+    return Array.from(domains.values());
   }
 );
 


### PR DESCRIPTION
## Done

- Add help for usernames.
- Add suggestions from previously used usernames.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Open the access panel for a model.
- You should see help below the username field with instructions on the username format.
- You should also see suggestions about domains that are in use on your models (if there are are any - if not add some external users and they should get added to the list).
- Enter in a username without the domain and click a domain and it should get appended to the username.

## Details

https://warthogs.atlassian.net/browse/WD-2929
Fixes: #1052.

## Screenshots

![Screen Recording 2023-03-31 at 10 42 07 am](https://user-images.githubusercontent.com/361637/228992417-72e68625-a3fe-455f-8c90-21999124d3d8.gif)

