### PR TITLE
WD-2985 - Improve tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "npm-package-json-lint": "6.4.0",
     "postcss": "8.4.21",
     "prettier": "2.8.2",
+    "react-anchorme": "3.0.0",
     "redux-devtools": "3.7.0",
     "redux-devtools-extension": "2.13.9",
     "redux-mock-store": "1.5.4",

--- a/src/components/ModelTableList/OwnerGroup.tsx
+++ b/src/components/ModelTableList/OwnerGroup.tsx
@@ -9,6 +9,7 @@ import {
   getModelStatusGroupData,
   Filters,
 } from "store/juju/utils/models";
+import TruncatedTooltip from "components/TruncatedTooltip";
 import { generateStatusElement } from "components/utils";
 
 import {
@@ -115,9 +116,11 @@ export default function OwnerGroup({ filters }: Props) {
           },
           {
             "data-testid": "column-cloud",
-            content: cloud,
-            className: "u-truncate",
-            title: generateCloudAndRegion(model),
+            content: (
+              <TruncatedTooltip message={generateCloudAndRegion(model)}>
+                {cloud}
+              </TruncatedTooltip>
+            ),
           },
           {
             "data-testid": "column-credential",

--- a/src/components/ModelTableList/StatusGroup.tsx
+++ b/src/components/ModelTableList/StatusGroup.tsx
@@ -1,7 +1,7 @@
-import { ReactNode } from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import { List, MainTable, Tooltip } from "@canonical/react-components";
+import { ListItem } from "@canonical/react-components/dist/components/List/List";
 import { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
 
 import { useQueryParams, SetParams } from "hooks/useQueryParams";
@@ -12,8 +12,8 @@ import {
   Filters,
   Status,
 } from "store/juju/utils/models";
+import TruncatedTooltip from "components/TruncatedTooltip";
 import { generateStatusElement } from "components/utils";
-
 import {
   getActiveUsers,
   getControllerData,
@@ -82,23 +82,26 @@ const generateWarningMessage = (model: ModelData) => {
     ownerTag,
     messages[0].message
   );
-  const list: ReactNode[] = messages.slice(0, 5).map((message) => {
+  const list: ListItem[] = messages.slice(0, 5).map((message) => {
     const unitId = message.unitId ? message.unitId.replace("/", "-") : null;
     const appName = message.appName;
-    return (
-      <>
-        {unitId || appName}:{" "}
-        <Link
-          to={
-            unitId
-              ? urls.model.unit({ userName, modelName, appName, unitId })
-              : urls.model.app.index({ userName, modelName, appName })
-          }
-        >
-          {message.message}
-        </Link>
-      </>
-    );
+    return {
+      className: "u-truncate",
+      content: (
+        <>
+          {unitId || appName}:{" "}
+          <Link
+            to={
+              unitId
+                ? urls.model.unit({ userName, modelName, appName, unitId })
+                : urls.model.app.index({ userName, modelName, appName })
+            }
+          >
+            {message.message}
+          </Link>
+        </>
+      ),
+    };
   });
   const remainder = messages.slice(5);
   if (remainder.length) {
@@ -106,8 +109,9 @@ const generateWarningMessage = (model: ModelData) => {
   }
   return (
     <Tooltip
-      className="p-tooltip--constrain-width"
-      message={<List className="u-no-margin--bottom u-truncate" items={list} />}
+      positionElementClassName="p-tooltip__position-element--inline"
+      tooltipClassName="p-tooltip--constrain-width"
+      message={<List className="u-no-margin--bottom" items={list} />}
     >
       <span className="model-table-list_error-message">{link}</span>
     </Tooltip>
@@ -192,9 +196,11 @@ function generateModelTableDataByStatus(
           },
           {
             "data-testid": "column-cloud",
-            content: cloud,
-            className: "u-truncate",
-            title: generateCloudAndRegion(model),
+            content: (
+              <TruncatedTooltip message={generateCloudAndRegion(model)}>
+                {cloud}
+              </TruncatedTooltip>
+            ),
           },
           {
             "data-testid": "column-credential",

--- a/src/components/ShareCard/ShareCard.tsx
+++ b/src/components/ShareCard/ShareCard.tsx
@@ -1,7 +1,8 @@
-import { Button, Select, Tooltip } from "@canonical/react-components";
+import { Button, Select } from "@canonical/react-components";
 import { useEffect, useState } from "react";
 
 import { formatFriendlyDateToNow } from "components/utils";
+import TruncatedTooltip from "components/TruncatedTooltip";
 
 import SlideDownFadeOut from "animations/SlideDownFadeOut";
 
@@ -70,14 +71,10 @@ export default function ShareCard({
     <div>
       <SlideDownFadeOut isAnimating={hasBeenRemoved}>
         <div className="share-card" data-active={inFocus}>
-          <div className="share-card__title u-truncate">
-            <Tooltip
-              message={userName}
-              className="u-truncate"
-              positionElementClassName="share-card__tooltip-wrapper"
-            >
+          <div className="share-card__title">
+            <TruncatedTooltip message={userName}>
               <strong className="share-card__username">{userName}</strong>
-            </Tooltip>
+            </TruncatedTooltip>
             <span className="share-card__secondary">
               {isOwner ? (
                 Label.OWNER

--- a/src/components/ShareCard/_share-card.scss
+++ b/src/components/ShareCard/_share-card.scss
@@ -102,9 +102,4 @@
       opacity: 1;
     }
   }
-
-  &__tooltip-wrapper {
-    // Override to allow long usernames to truncate.
-    display: inline !important;
-  }
 }

--- a/src/components/TruncatedTooltip/TruncatedTooltip.test.tsx
+++ b/src/components/TruncatedTooltip/TruncatedTooltip.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+
+import TruncatedTooltip from "./TruncatedTooltip";
+
+describe("TruncatedTooltip", () => {
+  const offsetWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "offsetWidth"
+  );
+  const scrollWidth = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollWidth"
+  );
+
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      value: 1000,
+    });
+  });
+
+  afterEach(() => {
+    if (offsetWidth) {
+      Object.defineProperty(HTMLElement.prototype, "offsetWidth", offsetWidth);
+    }
+    if (scrollWidth) {
+      Object.defineProperty(HTMLElement.prototype, "scrollWidth", scrollWidth);
+    }
+  });
+
+  it("hides the tooltip if the content fits", async () => {
+    const content = "Some content";
+    render(
+      <TruncatedTooltip message="Tooltip content">{content}</TruncatedTooltip>
+    );
+    expect(screen.getByTestId("tooltip-portal")).toHaveClass("u-hide");
+  });
+
+  it("displays the tooltip if the content is truncated", async () => {
+    const content = "Some content that is too long";
+    // jsdom does not implement the resize observer or element dimensions so the
+    // best we can do is mock the attributes we're using to check if the content
+    // is truncated.
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      value: 200,
+    });
+    render(
+      <TruncatedTooltip message="Tooltip content">{content}</TruncatedTooltip>
+    );
+    expect(screen.getByTestId("tooltip-portal")).not.toHaveClass("u-hide");
+  });
+});

--- a/src/components/TruncatedTooltip/TruncatedTooltip.tsx
+++ b/src/components/TruncatedTooltip/TruncatedTooltip.tsx
@@ -1,0 +1,86 @@
+import { Tooltip, TooltipProps } from "@canonical/react-components";
+import classNames from "classnames";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+  PropsWithChildren,
+} from "react";
+
+import "./_truncated-tooltip.scss";
+
+type Props = {
+  tooltipClassName?: TooltipProps["tooltipClassName"];
+  positionElementClassName?: TooltipProps["positionElementClassName"];
+  wrapperClassName?: string;
+} & TooltipProps &
+  PropsWithChildren;
+
+/**
+   This tooltip has a special power, it only appears if the content is truncated.
+*/
+const TruncatedTooltip = ({
+  children,
+  positionElementClassName,
+  tooltipClassName,
+  wrapperClassName,
+  ...tooltipProps
+}: Props) => {
+  const truncatedNode = useRef<HTMLDivElement>(null);
+  const [truncated, setTruncated] = useState(false);
+
+  const checkTruncated = useCallback(() => {
+    // Check to see if the content is larger than the frame, in which case the
+    // CSS will be truncating the element.
+    setTruncated(
+      (truncatedNode.current &&
+        truncatedNode.current.offsetWidth <
+          truncatedNode.current.scrollWidth) ||
+        false
+    );
+  }, [truncatedNode]);
+
+  const resizeObserver = useMemo(
+    () => new ResizeObserver(checkTruncated),
+    [checkTruncated]
+  );
+
+  useEffect(() => {
+    const element = truncatedNode.current;
+    if (!element) {
+      return;
+    }
+    // Do an initial check for whether the content is truncated.
+    checkTruncated();
+    // Watch the content for resizes to check if the truncation changes.
+    resizeObserver.observe(element);
+    return () => {
+      if (truncatedNode) {
+        resizeObserver.unobserve(element);
+      }
+    };
+  }, [checkTruncated, resizeObserver, truncatedNode]);
+
+  return (
+    <div className={classNames("truncated-tooltip", wrapperClassName)}>
+      <Tooltip
+        {...tooltipProps}
+        positionElementClassName={classNames(
+          positionElementClassName,
+          "truncated-tooltip__position-element"
+        )}
+        tooltipClassName={classNames(tooltipClassName, {
+          "u-hide": !truncated,
+        })}
+      >
+        <div ref={truncatedNode} className="u-truncate">
+          {children}
+        </div>
+      </Tooltip>
+    </div>
+  );
+};
+
+export default TruncatedTooltip;

--- a/src/components/TruncatedTooltip/_truncated-tooltip.scss
+++ b/src/components/TruncatedTooltip/_truncated-tooltip.scss
@@ -1,0 +1,4 @@
+.truncated-tooltip__position-element {
+  // Override to allow the content to truncate.
+  display: inline !important;
+}

--- a/src/components/TruncatedTooltip/index.ts
+++ b/src/components/TruncatedTooltip/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TruncatedTooltip";

--- a/src/components/utils.tsx
+++ b/src/components/utils.tsx
@@ -1,8 +1,11 @@
 import classNames from "classnames";
 import { parseISO, formatDistanceToNow } from "date-fns";
 import { ImgHTMLAttributes, useState } from "react";
+
+import TruncatedTooltip from "components/TruncatedTooltip";
 import defaultCharmIcon from "static/images/icons/default-charm-icon.svg";
 import { generateIconPath } from "store/juju/utils/models";
+
 import { ModelData } from "../juju/types";
 
 export function generateEntityIdentifier(
@@ -15,11 +18,11 @@ export function generateEntityIdentifier(
   }
 
   return (
-    <div className="entity-name u-truncate" title={name}>
+    <TruncatedTooltip message={name} wrapperClassName="entity-name">
       {subordinate && <span className="subordinate"></span>}
       {charmId && generateIconImg(name, charmId)}
       {name}
-    </div>
+    </TruncatedTooltip>
   );
 }
 

--- a/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.test.tsx
+++ b/src/pages/EntityDetails/Model/ApplicationsTab/ApplicationsTab.test.tsx
@@ -123,7 +123,7 @@ describe("ApplicationsTab", () => {
         /There are no applications associated with this model/i
       )
     ).not.toBeInTheDocument();
-    expect(screen.queryByText(/db1/i)).toBeInTheDocument();
+    expect(screen.queryAllByText(/db1/i)).toHaveLength(2);
   });
 
   it("shows all the application by default", () => {

--- a/src/pages/EntityDetails/_entity-details.scss
+++ b/src/pages/EntityDetails/_entity-details.scss
@@ -384,9 +384,8 @@
   /* stylelint-enable no-descending-specificity */
 
   // Override the status icon so that it truncates inside the tooltip wrapper.
-  .entity-details__machines .status-icon,
-  .entity-details__machines-status-icon {
-    display: inline !important;
+  .entity-details__machines .status-icon {
+    display: inline;
   }
 }
 

--- a/src/scss/_utils.scss
+++ b/src/scss/_utils.scss
@@ -43,6 +43,11 @@
   margin-top: 0.25rem;
 }
 
-.p-tooltip--constrain-width {
+.p-tooltip--constrain-width .p-tooltip__message {
   max-width: 20rem;
+  white-space: pre-wrap;
+}
+
+.p-tooltip__position-element--inline {
+  display: inline !important;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2970,6 +2970,11 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.6.0, ajv@^8.8.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+anchorme@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/anchorme/-/anchorme-2.1.2.tgz#4abc7e128a8a42d0036a61ebb9b18bbc032fa52a"
+  integrity sha512-2iPY3kxDDZvtRzauqKDb4v7a5sTF4GZ+esQTY8nGYvmhAtGTeFPMn4cRnvyWS1qmtPTP0Mv8hyLOp9l3ZzWMKg==
+
 ansi-escapes@^4.2.1, ansi-escapes@^4.3.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
@@ -8825,6 +8830,13 @@ raw-body@2.5.1:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+react-anchorme@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-anchorme/-/react-anchorme-3.0.0.tgz#273801ee7227113dc9abbbe1b740b73d5a7d14fe"
+  integrity sha512-0+50BpfUCeT2YfMfmrpGxYCzPe/UOOVl95BSqrKp9fMJvIon9oLoOlv9cnluEsfBpTwkFSu7hNDXtvDGhXjqdQ==
+  dependencies:
+    anchorme "^2.1.2"
 
 react-app-polyfill@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Done

- Make tooltips only appear if content is truncated.
- Turn urls into links in messages.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Have a look through the tables. Any columns with long content should get truncated.
- Columns that aren't truncated shouldn't show tooltips.
- Columns with urls in them should get turned into links (e.g. status messages - though I couldn't find a real status message with a URL in it).

## Details

https://warthogs.atlassian.net/browse/WD-2985
Fixes: #973.
Fixes: #531.
Fixes: #508.

## Screenshots

![Screen Recording 2023-04-03 at 5 09 39 pm](https://user-images.githubusercontent.com/361637/229437581-e62f4021-0749-46f2-a7c4-ccd66168adb5.gif)
<img width="300" alt="Screenshot 2023-04-03 at 5 08 24 pm" src="https://user-images.githubusercontent.com/361637/229437602-ce79000e-7902-4730-9d1c-a7b34666f3ab.png">

