### PR TITLE
WD-3058 - Handle the cloud/region column for JAAS.

### DIFF
--- a/src/pages/ControllersIndex/ControllersIndex.test.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.test.tsx
@@ -74,6 +74,28 @@ describe("Controllers table", () => {
     expect(screen.getAllByRole("row")[1]).toMatchSnapshot();
   });
 
+  it("handles cloud/region for JAAS", () => {
+    state.juju = jujuStateFactory.build({
+      controllers: {
+        "wss://jimm.jujucharms.com/api": [
+          controllerFactory.build({ path: "admin/jaas", uuid: "123" }),
+        ],
+      },
+      models: {},
+    });
+    const store = mockStore(state);
+    render(
+      <MemoryRouter>
+        <Provider store={store}>
+          <ControllersIndex />
+        </Provider>
+      </MemoryRouter>
+    );
+    expect(
+      screen.getByRole("gridcell", { name: "Multiple" })
+    ).toBeInTheDocument();
+  });
+
   it("shows 'Register new controller' panel", () => {
     const store = mockStore(state);
     render(

--- a/src/pages/ControllersIndex/ControllersIndex.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.tsx
@@ -13,6 +13,7 @@ import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import { getControllerData, getModelData } from "store/juju/selectors";
 import { AdditionalController, Controller } from "store/juju/types";
+import { isJAASFromPath } from "store/juju/utils/controllers";
 import urls from "urls";
 
 import ControllersOverview from "./ControllerOverview/ControllerOverview";
@@ -25,9 +26,6 @@ type AnnotatedController = (Controller | AdditionalController) & {
   units: number;
   wsControllerURL: string;
 };
-
-const isJAAS = (controllerData: AnnotatedController) =>
-  "path" in controllerData && controllerData?.path === "admin/jaas";
 
 function Details() {
   useWindowTitle("Controllers");
@@ -107,7 +105,7 @@ function Details() {
 
   function generatePathValue(controllerData: AnnotatedController) {
     const column: MainTableCell = { content: "" };
-    if (isJAAS(controllerData)) {
+    if (isJAASFromPath(controllerData)) {
       column.content = "JAAS";
     } else if ("path" in controllerData && controllerData.path) {
       column.content = controllerData.path;
@@ -128,7 +126,7 @@ function Details() {
     const access = "Public" in c && c.Public ? "Public" : "Private";
     let columns = [
       generatePathValue(c),
-      { content: isJAAS(c) ? "Multiple" : cloudRegion },
+      { content: isJAASFromPath(c) ? "Multiple" : cloudRegion },
       { content: c.models },
       { content: c.machines },
       { content: c.applications },

--- a/src/pages/ControllersIndex/ControllersIndex.tsx
+++ b/src/pages/ControllersIndex/ControllersIndex.tsx
@@ -26,6 +26,9 @@ type AnnotatedController = (Controller | AdditionalController) & {
   wsControllerURL: string;
 };
 
+const isJAAS = (controllerData: AnnotatedController) =>
+  "path" in controllerData && controllerData?.path === "admin/jaas";
+
 function Details() {
   useWindowTitle("Controllers");
   const controllerData = useSelector(getControllerData);
@@ -104,7 +107,7 @@ function Details() {
 
   function generatePathValue(controllerData: AnnotatedController) {
     const column: MainTableCell = { content: "" };
-    if ("path" in controllerData && controllerData?.path === "admin/jaas") {
+    if (isJAAS(controllerData)) {
       column.content = "JAAS";
     } else if ("path" in controllerData && controllerData.path) {
       column.content = controllerData.path;
@@ -125,7 +128,7 @@ function Details() {
     const access = "Public" in c && c.Public ? "Public" : "Private";
     let columns = [
       generatePathValue(c),
-      { content: cloudRegion },
+      { content: isJAAS(c) ? "Multiple" : cloudRegion },
       { content: c.models },
       { content: c.machines },
       { content: c.applications },

--- a/src/pages/ControllersIndex/__snapshots__/ControllersIndex.test.tsx.snap
+++ b/src/pages/ControllersIndex/__snapshots__/ControllersIndex.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Controllers table counts models, machines, apps, and units 1`] = `
     class=""
     role="gridcell"
   >
-    unknown/unknown
+    Multiple
   </td>
   <td
     aria-hidden="false"

--- a/src/store/juju/utils/controllers.test.ts
+++ b/src/store/juju/utils/controllers.test.ts
@@ -1,0 +1,16 @@
+import {
+  additionalControllerFactory,
+  controllerFactory,
+} from "testing/factories/juju/juju";
+
+import { isJAASFromPath } from "./controllers";
+
+describe("isJAASFromPath", () => {
+  it("identifies a JAAS controller from the path", () => {
+    expect(isJAASFromPath(controllerFactory.build())).toBe(true);
+  });
+
+  it("identifies a non-JAAS controller from the path", () => {
+    expect(isJAASFromPath(additionalControllerFactory.build())).toBe(false);
+  });
+});

--- a/src/store/juju/utils/controllers.ts
+++ b/src/store/juju/utils/controllers.ts
@@ -1,0 +1,5 @@
+import { AdditionalController, Controller } from "store/juju/types";
+
+export const isJAASFromPath = (
+  controllerData: Controller | AdditionalController
+) => "path" in controllerData && controllerData?.path === "admin/jaas";


### PR DESCRIPTION
## Done

- Handle the cloud/region column for JAAS.

## QA

- Pull code
- Run `dotrun clean && dotrun serve`
- Open http://0.0.0.0:8036/
- Connect to JAAS.
- Go to the list of controllers.
- In the cloud/region column it should say "Multiple" for the JAAS row.

## Details

https://warthogs.atlassian.net/browse/WD-3058
Fixes: #629.

## Screenshots

<img width="245" alt="Screenshot 2023-04-05 at 1 37 37 pm" src="https://user-images.githubusercontent.com/361637/229976299-542e8f9d-d35c-4376-86db-15cf96abe5da.png">

